### PR TITLE
make beneath infixl 6

### DIFF
--- a/src/Diagrams/Combinators.hs
+++ b/src/Diagrams/Combinators.hs
@@ -112,6 +112,8 @@ beneath :: (HasLinearMap v, OrderedField (Scalar v), InnerSpace v, Monoid' m)
      => QDiagram b v m -> QDiagram b v m -> QDiagram b v m
 beneath = flip atop
 
+infixl 6 `beneath`
+
 -- | Place two monoidal objects (/i.e./ diagrams, paths,
 --   animations...) next to each other along the given vector.  In
 --   particular, place the second object so that the vector points


### PR DESCRIPTION
While playing with diagrams-ghci, mgsloan and I noticed that `beneath` did not have the same precedence as `<>` (or `atop`).  This commit gives `beneath` the same fixity and precedence as `atop`, namely, `infixl 6`.

The only question is why `atop` is `infixl`, as opposed to `<>` which is `infixr`.  I don't remember if I had a good reason for this when I initially gave `atop` its fixity.
