### PR TITLE
Added `Eq` instances for some data structures.

### DIFF
--- a/src/Diagrams/Attributes.hs
+++ b/src/Diagrams/Attributes.hs
@@ -238,7 +238,7 @@ data LineCap = LineCapButt   -- ^ Lines end precisely at their endpoints.
   deriving (Eq,Show,Typeable)
 
 newtype LineCapA = LineCapA (Last LineCap)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass LineCapA
 
 getLineCap :: LineCapA -> LineCap
@@ -258,7 +258,7 @@ data LineJoin = LineJoinMiter    -- ^ Use a \"miter\" shape (whatever that is).
   deriving (Eq,Show,Typeable)
 
 newtype LineJoinA = LineJoinA (Last LineJoin)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass LineJoinA
 
 getLineJoin :: LineJoinA -> LineJoin
@@ -270,10 +270,10 @@ lineJoin = applyAttr . LineJoinA . Last
 
 -- | Create lines that are dashing... er, dashed.
 data Dashing = Dashing [Double] Double
-  deriving Typeable
+  deriving (Typeable, Eq)
 
 newtype DashingA = DashingA (Last Dashing)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass DashingA
 
 getDashing :: DashingA -> Dashing

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -187,6 +187,7 @@ data FillRule = Winding  -- ^ Interior points are those with a nonzero
                          --   direction crosses the path an odd number
                          --   of times. See
                          --   <http://en.wikipedia.org/wiki/Even-odd_rule>.
+    deriving (Eq)
 
 runFillRule :: FillRule -> P2 -> Path R2 -> Bool
 runFillRule Winding = isInsideWinding

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -119,7 +119,7 @@ baselineText = mkText BaselineText
 -- | The @Font@ attribute specifies the name of a font family.  Inner
 --   @Font@ attributes override outer ones.
 newtype Font = Font (Last String)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass Font
 
 -- | Extract the font family name from a @Font@ attribute.
@@ -137,7 +137,7 @@ font = applyAttr . Font . Last
 --   em-square, measured with respect to the current local vector space.
 --   Inner @FontSize@ attributes override outer ones.
 newtype FontSize = FontSize (Last Double)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass FontSize
 
 -- | Extract the size from a @FontSize@ attribute.
@@ -156,12 +156,13 @@ fontSize = applyAttr . FontSize . Last
 data FontSlant = FontSlantNormal
                | FontSlantItalic
                | FontSlantOblique
+    deriving (Eq)
 
 -- | The @FontSlantA@ attribute specifies the slant (normal, italic,
 --   or oblique) that should be used for all text within a diagram.
 --   Inner @FontSlantA@ attributes override outer ones.
 newtype FontSlantA = FontSlantA (Last FontSlant)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass FontSlantA
 
 -- | Extract the font slant from a 'FontSlantA' attribute.
@@ -187,12 +188,13 @@ oblique = fontSlant FontSlantOblique
 
 data FontWeight = FontWeightNormal
                 | FontWeightBold
+    deriving (Eq)
 
 -- | The @FontWeightA@ attribute specifies the weight (normal or bold)
 --   that should be used for all text within a diagram.  Inner
 --   @FontWeightA@ attributes override outer ones.
 newtype FontWeightA = FontWeightA (Last FontWeight)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable, Semigroup, Eq)
 instance AttributeClass FontWeightA
 
 -- | Extract the font weight from a 'FontWeightA' attribute.


### PR DESCRIPTION
These `Eq` instances are for structures likely to be shared by backends.  In
particular I use them in `Postscript` when tracking render state.
