### PR TITLE
Big refactoring of segments and trails.

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -30,7 +30,10 @@ Library
                        Diagrams.Coordinates,
                        Diagrams.Attributes,
                        Diagrams.Points,
+                       Diagrams.Located,
                        Diagrams.Segment,
+                       Diagrams.Trail,
+                       Diagrams.TrailLike,
                        Diagrams.Path,
                        Diagrams.CubicSpline,
                        Diagrams.CubicSpline.Internal,
@@ -74,5 +77,6 @@ Library
                        colour >= 2.3.2 && < 2.4,
                        data-default-class < 0.1,
                        pretty >= 1.0.1.2 && < 1.2,
-                       newtype >= 0.2 && < 0.3
+                       newtype >= 0.2 && < 0.3,
+                       fingertree >= 0.1 && < 0.2
   Hs-source-dirs:      src

--- a/src/Diagrams/Animation.hs
+++ b/src/Diagrams/Animation.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE TypeFamilies
-           , FlexibleContexts
-           , MultiParamTypeClasses
-  #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Animation
@@ -30,21 +29,21 @@ module Diagrams.Animation
 
        ) where
 
-import Diagrams.Core
+import           Diagrams.Core
 
-import Diagrams.Combinators
-import Diagrams.Animation.Active ()
-import Diagrams.BoundingBox
-import Diagrams.TwoD.Shapes
-import Diagrams.TwoD.Types
-import Diagrams.Path
+import           Diagrams.Animation.Active ()
+import           Diagrams.BoundingBox
+import           Diagrams.Combinators
+import           Diagrams.TrailLike
+import           Diagrams.TwoD.Shapes
+import           Diagrams.TwoD.Types
 
-import Data.Active
-import Data.Semigroup
+import           Data.Active
+import           Data.Semigroup
 
-import Control.Applicative ((<$>))
-import Data.Foldable       (foldMap)
-import Data.VectorSpace
+import           Control.Applicative       ((<$>))
+import           Data.Foldable             (foldMap)
+import           Data.VectorSpace
 
 -- | A value of type @QAnimation b v m@ is an animation (a
 --   time-varying diagram with start and end times) that can be
@@ -110,16 +109,16 @@ animEnvelope' r a = withEnvelope (simulate r a) <$> a
 --
 --   Uses 30 samples per time unit by default; to adjust this number
 --   see 'animRect''.
-animRect :: (PathLike p, Enveloped p, Transformable p, V p ~ R2)
-         => QAnimation b R2 m -> p
+animRect :: (TrailLike t, Enveloped t, Transformable t, Monoid t, V t ~ R2)
+         => QAnimation b R2 m -> t
 animRect = animRect' 30
 
 -- | Like 'animRect', but with an adjustible sample rate.  The first
 --   parameter is the number of samples per time unit to use.  Lower
 --   rates will be faster but less accurate; higher rates are more
 --   accurate but slower.
-animRect' :: (PathLike p, Enveloped p, Transformable p, V p ~ R2)
-          => Rational -> QAnimation b R2 m -> p
+animRect' :: (TrailLike t, Enveloped t, Transformable t, Monoid t, V t ~ R2)
+          => Rational -> QAnimation b R2 m -> t
 animRect' r anim
     | null results = rect 1 1
     | otherwise    = boxFit (foldMap boundingBox results) (rect 1 1)

--- a/src/Diagrams/Animation/Active.hs
+++ b/src/Diagrams/Animation/Active.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeFamilies
-  #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -17,8 +16,8 @@
 --   * 'HasOrigin', 'Transformable', and 'HasStyle' instances for
 --     'Active' which all work pointwise.
 --
---   * A 'PathLike' instance for @'Active' p@ where @p@ is also
---     'PathLike', which simply lifts a pathlike thing to a constant
+--   * A 'TrailLike' instance for @'Active' p@ where @p@ is also
+--     'TrailLike', which simply lifts a pathlike thing to a constant
 --     active value.
 --
 --   * A 'Juxtaposable' instance for @'Active' a@ where @a@ is also
@@ -38,13 +37,14 @@
 
 module Diagrams.Animation.Active where
 
-import Diagrams.Core
-import Control.Applicative ((<$>), pure)
+import           Control.Applicative (pure, (<$>))
 
-import Diagrams.Align
-import Diagrams.Path
+import           Diagrams.Align
+import           Diagrams.Core
+import           Diagrams.Path
+import           Diagrams.TrailLike
 
-import Data.Active
+import           Data.Active
 
 type instance V (Active a) = V a
 
@@ -63,8 +63,8 @@ instance Transformable a => Transformable (Active a) where
 instance HasStyle a => HasStyle (Active a) where
   applyStyle = fmap . applyStyle
 
-instance PathLike p => PathLike (Active p) where
-  pathLike st cl segs = pure (pathLike st cl segs)
+instance TrailLike t => TrailLike (Active t) where
+  trailLike = pure . trailLike
 
 -- | An active value can be juxtaposed against another by doing the
 --   juxtaposition pointwise over time.  The era of @juxtapose v a1

--- a/src/Diagrams/Backend/Show.hs
+++ b/src/Diagrams/Backend/Show.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE FlexibleInstances
-           , FlexibleContexts
-           , MultiParamTypeClasses
-           , ScopedTypeVariables
-           , TypeSynonymInstances
-           , TypeFamilies
-           , GeneralizedNewtypeDeriving
-  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Backend.Show
@@ -18,15 +17,16 @@
 -----------------------------------------------------------------------------
 module Diagrams.Backend.Show where
 
-import Diagrams.Prelude
-import Diagrams.Core.Transform (onBasis)
+import           Diagrams.Core.Transform (onBasis)
+import           Diagrams.Prelude
+import           Diagrams.Trail
 
-import Data.Basis
+import           Data.Basis
 
-import Text.PrettyPrint (Doc, empty, ($+$), parens, hsep)
-import qualified Text.PrettyPrint as PP
+import           Text.PrettyPrint        (Doc, empty, hsep, parens, ($+$))
+import qualified Text.PrettyPrint        as PP
 
-import Data.List (transpose)
+import           Data.List               (transpose)
 
 -- | Token for identifying this backend.
 data ShowBackend = ShowBackend
@@ -59,11 +59,11 @@ renderMat :: Show a => [[a]] -> Doc
 renderMat = PP.vcat . map renderRow . transpose
   where renderRow = parens . hsep . map (PP.text . show)
 
-instance (Show v, HasLinearMap v) => Renderable (Segment v) ShowBackend where
+instance (Show v, HasLinearMap v) => Renderable (Segment o v) ShowBackend where
   render _ s = SR $ PP.text (show s)
 
-instance (Show v, HasLinearMap v) => Renderable (Trail v) ShowBackend where
+instance (Show v, OrderedField (Scalar v), InnerSpace v, HasLinearMap v) => Renderable (Trail v) ShowBackend where
   render _ t = SR $ PP.text (show t)
 
-instance (Ord v, Show v, HasLinearMap v) => Renderable (Path v) ShowBackend where
+instance (Show v, OrderedField (Scalar v), InnerSpace v, HasLinearMap v) => Renderable (Path v) ShowBackend where
   render _ p = SR $ PP.text (show p)

--- a/src/Diagrams/CubicSpline.hs
+++ b/src/Diagrams/CubicSpline.hs
@@ -25,8 +25,11 @@ module Diagrams.CubicSpline
 import           Diagrams.Core
 import           Diagrams.Core.Points
 import           Diagrams.CubicSpline.Internal
+import           Diagrams.Located              (at)
 import           Diagrams.Path
 import           Diagrams.Segment
+import           Diagrams.Trail                (trailFromSegments)
+import           Diagrams.TrailLike            (TrailLike (..))
 
 -- for e.g. the Fractional (Double, Double) instance
 import           Data.NumInstances.Tuple       ()
@@ -38,10 +41,10 @@ import           Data.Semigroup
 --   vertices, with the first vertex as the starting point.  The first
 --   argument specifies whether the path should be closed.
 --   See: <http://mathworld.wolfram.com/CubicSpline.html>
-cubicSpline :: (PathLike p, Fractional (V p)) => Bool -> [Point (V p)] -> p
+cubicSpline :: (Monoid t, TrailLike t, Fractional (V t)) => Bool -> [Point (V t)] -> t
 cubicSpline _      [] = mempty
 cubicSpline closed ps = flattenBeziers . map f . solveCubicSplineCoefficients closed . map unpack $ ps
   where
     f [a,b,c,d] = [a, (3*a+b)/3, (3*a+2*b+c)/3, a+b+c+d]
-    flattenBeziers bs@((b:_):_) = pathLike (P b) False (map bez bs)
+    flattenBeziers bs@((b:_):_) = trailLike (trailFromSegments (map bez bs) `at` P b)
     bez [a,b,c,d] = bezier3 (b - a) (c - a) (d - a)

--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams.Located
+-- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- \"Located\" things, /i.e./ things with a concrete location:
+-- intuitively, @Located a ~ (a, Point)@.  Wrapping a translationally
+-- invariant thing (/e.g./ a 'Segment' or 'Trail') in @Located@ pins
+-- it down to a particular location and makes it no longer
+-- translationally invariant.
+--
+-----------------------------------------------------------------------------
+
+module Diagrams.Located
+    ( Located
+    , at, viewLoc, unLoc, loc, mapLoc
+    )
+    where
+
+import           Data.VectorSpace
+
+import           Diagrams.Core
+import           Diagrams.Core.Points
+  -- for GHC 7.4 type family bug
+
+-- | \"Located\" things, /i.e./ things with a concrete location:
+--   intuitively, @Located a ~ (Point, a)@.  Wrapping a translationally
+--   invariant thing (/e.g./ a 'Segment' or 'Trail') in 'Located' pins
+--   it down to a particular location and makes it no longer
+--   translationally invariant.
+--
+--   @Located@ is intentionally abstract.  To construct @Located@
+--   values, use 'at'.  To destruct, use 'viewLoc', 'unLoc', or 'loc'.
+--   To map, use 'mapLoc'.
+--
+--   Much of the utility of having a concrete type for the @Located@
+--   concept lies in the type class instances we can give it.  The
+--   'HasOrigin', 'Transformable', 'Enveloped', 'Traced', and
+--   'TrailLike' instances are particularly useful; see the documented
+--   instances below for more information.
+data Located a = Loc { loc :: Point (V a)   -- ^ Project out the
+                                            --   location of a @Located@
+                                            --   value.
+                     , obj :: TransInv a
+                     }
+
+infix 5 `at`
+
+-- | Construct a @Located a@ from a value of type @a@ and a location.
+--   @at@ is intended to be used infix, like @x \`at\` origin@.
+at :: a -> Point (V a) -> Located a
+at a p = Loc p (TransInv a)
+
+-- | Project the value of type @a@ out of a @Located a@, discarding
+--   the location.
+unLoc :: Located a -> a
+unLoc (Loc _ (TransInv a)) = a
+
+-- | Deconstruct a @Located a@ into a location and a value of type
+--   @a@.  @viewLoc@ can be especially useful in conjunction with the
+--   @ViewPatterns@ extension.
+viewLoc :: Located a -> (Point (V a), a)
+viewLoc (Loc p (TransInv a)) = (p,a)
+
+-- | 'Located' is not a @Functor@, since changing the type could
+--   change the type of the associated vector space, in which case the
+--   associated location would no longer have the right type. 'mapLoc'
+--   has an extra constraint specifying that the vector space must
+--   stay the same.
+--
+--   (Technically, one can say that for every vector space @v@,
+--   @Located@ is a little-f (endo)functor on the category of types
+--   with associated vector space @v@; but that is not covered by the
+--   standard @Functor@ class.)
+mapLoc :: (V a ~ V b) => (a -> b) -> Located a -> Located b
+mapLoc f (Loc p (TransInv a)) = Loc p (TransInv (f a))
+
+deriving instance (Eq   (V a), Eq a  ) => Eq   (Located a)
+deriving instance (Ord  (V a), Ord a ) => Ord  (Located a)
+deriving instance (Show (V a), Show a) => Show (Located a)
+
+type instance V (Located a) = V a
+
+-- | @Located a@ is an instance of @HasOrigin@ whether @a@ is or not.
+--   In particular, translating a @Located a@ simply translates the
+--   associated point (and does /not/ affect the value of type @a@).
+instance VectorSpace (V a) => HasOrigin (Located a) where
+  moveOriginTo o (Loc p a) = Loc (moveOriginTo o p) a
+
+-- | Applying a transformation @t@ to a @Located a@ results in the
+--   transformation being applied to the location, and the /linear/
+--   /portion/ of @t@ being applied to the value of type @a@ (/i.e./
+--   it is not translated).
+instance Transformable a => Transformable (Located a) where
+  transform t (Loc p a) = Loc (transform t p) (transform t a)
+
+-- | The envelope of a @Located a@ is the envelope of the @a@,
+--   translated to the location.
+instance Enveloped a => Enveloped (Located a) where
+  getEnvelope (Loc p a) = moveTo p (getEnvelope a)
+
+instance Enveloped a => Juxtaposable (Located a) where
+  juxtapose = juxtaposeDefault
+
+-- | The trace of a @Located a@ is the trace of the @a@,
+--   translated to the location.
+instance Traced a => Traced (Located a) where
+  getTrace (Loc p a) = moveTo p (getTrace a)
+
+instance Qualifiable a => Qualifiable (Located a) where
+  n |> (Loc p a) = Loc p (n |> a)

--- a/src/Diagrams/Path.hs
+++ b/src/Diagrams/Path.hs
@@ -1,12 +1,13 @@
-{-# LANGUAGE TypeFamilies
-           , MultiParamTypeClasses
-           , FlexibleInstances
-           , FlexibleContexts
-           , DeriveFunctor
-           , GeneralizedNewtypeDeriving
-           , UndecidableInstances
-           , ScopedTypeVariables
-  #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Path
@@ -14,288 +15,97 @@
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
--- This module defines /trails/ (translationally invariant sequences
--- of linear or cubic Bézier segments) and /paths/ (collections of
--- concretely located trails).  Trails and paths can be used for
--- drawing shapes, laying out other diagrams, clipping, and other
--- things.
+-- This module defines /paths/, which are collections of concretely
+-- located 'Trail's.  Many drawing systems (cairo, svg, ...) have a
+-- similar notion of \"path\".  Note that paths with multiple trails
+-- are necessary for being able to draw /e.g./ filled objects with
+-- holes in them.
 --
 -----------------------------------------------------------------------------
 
 module Diagrams.Path
        (
-         -- * Constructing path-like things
-
-         PathLike(..), fromSegments, fromOffsets, fromVertices, segmentsFromVertices
-       , pathLikeFromTrail
-
-         -- * Closeable things
-
-       , Closeable(..)
-
-         -- * Trails
-
-       , Trail(..)
-
-         -- ** Computing with trails
-
-       , trailSegments'
-       , trailOffsets, trailOffset
-       , trailVertices, reverseTrail
-       , addClosingSegment
-       , fixTrail
 
          -- * Paths
 
-       , Path(..)
+         Path(..)
 
-         -- ** Constructing paths from trails
+         -- * Constructing paths
+         -- $construct
 
        , pathFromTrail
        , pathFromTrailAt
+       , pathFromLocTrail
 
-         -- ** Computing with paths
+         -- * Eliminating paths
 
        , pathVertices
        , pathOffsets
        , pathCentroid
+       , fixPath
+
+         -- * Modifying paths
+
        , scalePath
        , reversePath
-       , fixPath
 
          -- * Miscellaneous
 
-       , explodeTrail
        , explodePath
-       , (~~)
 
        ) where
 
-import Diagrams.Core
-import Diagrams.Core.Points
+import           Diagrams.Align
+import           Diagrams.Core
+import           Diagrams.Core.Points
+import           Diagrams.Located
+import           Diagrams.Points
+import           Diagrams.Segment
+import           Diagrams.Trail
+import           Diagrams.TrailLike
+import           Diagrams.Transform
 
-import Diagrams.Align
-import Diagrams.Segment
-import Diagrams.Points
-import Diagrams.Transform
-
-import Data.VectorSpace
-import Data.AffineSpace
-
-import Control.Newtype hiding (under)
-import Data.Semigroup
-import qualified Data.Foldable as F
-
-import Data.List (mapAccumL)
-
-import Control.Arrow ((***), first, second)
-
-------------------------------------------------------------
---  PathLike class
-------------------------------------------------------------
-
--- | Type class for path-like things, which must be monoids.
---   Instances include 'Trail's, 'Path's, and two-dimensional 'Diagram's.
-class (Monoid' p, VectorSpace (V p)) => PathLike p where
-
-  pathLike :: Point (V p)      -- ^ The starting point of the
-                               --   path.  Some path-like things
-                               --   (e.g. 'Trail's) may ignore this.
-           -> Bool             -- ^ Should the path be closed?
-           -> [Segment (V p)]  -- ^ Segments of the path.
-           -> p
-
--- | A list of points is path-like; this instance simply computes the
---   vertices of a path-like thing.
-instance VectorSpace v => PathLike [Point v] where
-  pathLike start cl segs = trailVertices start (pathLike start cl segs)
-
--- | Construct an open path-like thing with the origin as a starting
---   point.
-fromSegments :: PathLike p => [Segment (V p)] -> p
-fromSegments = pathLike origin False
-
--- | Construct an open path-like thing of linear segments from a list
---   of offsets.  The starting point is the origin.
-fromOffsets :: PathLike p => [V p] -> p
-fromOffsets = pathLike origin False . map Linear
-
--- | Construct a path-like thing of linear segments from a list of
---   vertices, with the first vertex as the starting point.
-fromVertices :: PathLike p => [Point (V p)] -> p
-fromVertices []         = mempty
-fromVertices vvs@(v:_) = pathLike v False (segmentsFromVertices vvs)
-
--- | Construct a list of linear segments from a list of vertices.  The
---   input list must contain at least two points to generate a
---   non-empty list of segments.
-segmentsFromVertices :: AdditiveGroup v => [Point v] -> [Segment v]
-segmentsFromVertices [] = []
-segmentsFromVertices vvs@(_:vs) = map Linear (zipWith (flip (.-.)) vvs vs)
-
-------------------------------------------------------------
---  Closeable class
-------------------------------------------------------------
-
--- | Path-like things that can be \"open\" or \"closed\".
-class PathLike p => Closeable p where
-  -- | \"Open\" a path-like thing.
-  open  :: p -> p
-
-  -- | \"Close\" a path-like thing, by implicitly connecting the
-  --   endpoint(s) back to the starting point(s).
-  close :: p -> p
-
-instance VectorSpace v => Closeable (Trail v) where
-  close (Trail segs _) = Trail segs True
-  open  (Trail segs _) = Trail segs False
-
-instance VectorSpace v => Closeable (Path v) where
-  close = (over Path . map . second) close
-  open  = (over Path . map . second) open
-
-------------------------------------------------------------
---  Trails  ------------------------------------------------
-------------------------------------------------------------
-
--- | A /trail/ is a sequence of segments placed end-to-end.  Trails
---   are thus translationally invariant, and form a monoid under
---   concatenation.  Trails can also be /open/ (the default) or
---   /closed/ (the final point in a closed trail is implicitly
---   connected back to the starting point).
-data Trail v = Trail { trailSegments :: [Segment v]
-                     , isClosed      :: Bool
-                     }
-  deriving (Show, Functor, Eq, Ord)
-
-type instance V (Trail v) = v
-
-instance Semigroup (Trail v) where
-  Trail t1 c1 <> Trail t2 c2 = Trail (t1 ++ t2) (c1 || c2)
-
--- | The empty trail has no segments.  Trails are composed via
---   concatenation.  @t1 ``mappend`` t2@ is closed iff either @t1@ or
---   @t2@ are.
-instance Monoid (Trail v) where
-  mempty = Trail [] False
-  mappend = (<>)
-
--- | Trails are 'PathLike' things.  Note that since trails are
---   translationally invariant, 'setStart' has no effect.
---   'fromSegments' creates an open trail.
-instance VectorSpace v => PathLike (Trail v) where
-  pathLike _ cl segs = Trail segs cl
-
-instance HasLinearMap v => Transformable (Trail v) where
-  transform t (Trail segs c) = Trail (transform t segs) c
-
--- | The envelope for a trail is based at the trail's start.
-instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Trail v) where
-
-  getEnvelope (Trail segs _) =
-    foldr (\seg bds -> moveOriginBy (negateV . segOffset $ seg) bds <> getEnvelope seg)
-          mempty
-          segs
-
-  -- XXX can we improve the efficiency of the above?  E.g. note the
-  -- last segment in each trail ends up getting translated O(n) times,
-  -- so overall we do O(n^2) work!  (to find the max over the bounds
-  -- for O(n) segments, where the ith segment requires working through
-  -- a stack of i translations...)
-  --
-  -- The idea would be to first convert to a list of FixedSegments (to
-  -- cache the translation work) then take the bounds of those.
-  --
-  -- Also, use a balanced fold!
-  --
-  -- Need to make some benchmarks I guess.
-
-instance HasLinearMap v => Renderable (Trail v) NullBackend where
-  render _ _ = mempty
-
-------------------------------------------------------------
---  Computing with trails  ---------------------------------
-------------------------------------------------------------
-
--- | @trailSegments'@ is like 'trailSegments', but explicitly includes
---   the implicit closing segment at the end of the list for closed trails.
-trailSegments' :: AdditiveGroup v => Trail v -> [Segment v]
-trailSegments' t | isClosed t = trailSegments t
-                                ++ [straight . negateV . trailOffset $ t]
-                 | otherwise  = trailSegments t
-
--- | Extract the offsets of the segments of a trail.
-trailOffsets :: Trail v -> [v]
-trailOffsets (Trail segs _) = map segOffset segs
-
--- | Compute the offset from the start of a trail to the end.
-trailOffset :: AdditiveGroup v => Trail v -> v
-trailOffset = sumV . trailOffsets
-
--- | Extract the vertices of a trail, given a concrete location at
---   which to place the first vertex.
-trailVertices :: AdditiveGroup v => Point v -> Trail v -> [Point v]
-trailVertices p = scanl (.+^) p . trailOffsets
-
--- | Reverse a trail's direction of travel.
-reverseTrail :: AdditiveGroup v => Trail v -> Trail v
-reverseTrail t@(Trail {trailSegments = []}) = t
-reverseTrail t@(Trail {trailSegments = ss})
-  | isClosed t = t { trailSegments = straight (trailOffset t) : reverseSegs ss }
-  | otherwise  = t { trailSegments = reverseSegs ss }
-  where reverseSegs = fmap reverseSegment . reverse
-
--- | Reverse a trail with a fixed starting point.
-reverseRootedTrail :: AdditiveGroup v => (Point v, Trail v) -> (Point v, Trail v)
-reverseRootedTrail (p, t)
-  | isClosed t = (p, reverseTrail t)
-  | otherwise  = (p .+^ trailOffset t, reverseTrail t)
-
--- | Convert a trail to any path-like thing.  @pathLikeFromTrail@ is the
---   identity on trails.
-pathLikeFromTrail :: PathLike p => Trail (V p) -> p
-pathLikeFromTrail t = pathLike origin (isClosed t) (trailSegments t)
-
--- | If the trail is closed, this adds in the closing segment. Otherwise,
---   the trail is returned unmodified.
-addClosingSegment :: AdditiveGroup v => Trail v -> Trail v
-addClosingSegment t | isClosed t = Trail (trailSegments t ++ [closeSeg]) False
-                    | otherwise = t
- where closeSeg = Linear . negateV $ trailOffset t
-
--- | Convert a starting point and a trail into a list of fixed segments.
-fixTrail :: AdditiveGroup v => Point v -> Trail v -> [FixedSegment v]
-fixTrail start t = zipWith mkFixedSeg (trailVertices start t)
-                                      (trailSegments $ addClosingSegment t)
+import           Control.Arrow        (first, second, (***))
+import           Control.Newtype      hiding (under)
+import           Data.AffineSpace
+import qualified Data.Foldable        as F
+import           Data.List            (mapAccumL)
+import           Data.Semigroup
+import           Data.VectorSpace
 
 ------------------------------------------------------------
 --  Paths  -------------------------------------------------
 ------------------------------------------------------------
 
--- | A /path/ is a (possibly empty) list of trails, with each
---   trail paired with an absolute starting point. Hence, paths
---   are /not/ translationally invariant, and form a monoid under
---   superposition.
-newtype Path v = Path { pathTrails :: [(Point v, Trail v)] }
-  deriving (Show, Semigroup, Monoid, Eq, Ord)
+-- | A /path/ is a (possibly empty) list of 'Located' 'Trail's.
+--   Hence, unlike trails, paths are not translationally invariant,
+--   and they form a monoid under /superposition/ (placing one path on
+--   top of another) rather than concatenation.
+newtype Path v = Path { pathTrails :: [Located (Trail v)] }
+  deriving (Semigroup, Monoid)
+
+deriving instance Show v => Show (Path v)
+deriving instance Eq   v => Eq   (Path v)
+deriving instance Ord  v => Ord  (Path v)
 
 type instance V (Path v) = v
 
-instance Newtype (Path v) [(Point v, Trail v)] where
+instance Newtype (Path v) [Located (Trail v)] where
   pack   = Path
   unpack = pathTrails
 
 instance VectorSpace v => HasOrigin (Path v) where
-  moveOriginTo = over Path . map . first . moveOriginTo
+  moveOriginTo = over Path . map . moveOriginTo
 
--- | Paths are (of course) path-like. 'fromSegments' creates a path
---   with start point at the origin.
-instance VectorSpace v => PathLike (Path v) where
-  pathLike s cl segs = Path [(s, pathLike origin cl segs)]
+-- | Paths are trail-like; a trail can be used to construct a
+--   singleton path.
+instance (InnerSpace v, OrderedField (Scalar v)) => TrailLike (Path v) where
+  trailLike = Path . (:[])
 
 -- See Note [Transforming paths]
-instance HasLinearMap v => Transformable (Path v) where
-  transform t = (over Path . map) (transform t *** transform t)
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Transformable (Path v) where
+  transform = over Path . map . transform
 
 {- ~~~~ Note [Transforming paths]
 
@@ -307,13 +117,13 @@ but that doesn't take into account the fact that some
 of the v's are inside Points and hence ought to be translated.
 -}
 
-instance HasLinearMap v => IsPrim (Path v)
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v)) => IsPrim (Path v)
 
 instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Path v) where
   getEnvelope = F.foldMap trailEnvelope . pathTrails
           -- this type signature is necessary to work around an apparent bug in ghc 6.12.1
-    where trailEnvelope :: (Point v, Trail v) -> Envelope v
-          trailEnvelope (p, t) = moveOriginTo ((-1) *. p) (getEnvelope t)
+    where trailEnvelope :: Located (Trail v) -> Envelope v
+          trailEnvelope (viewLoc -> (p, t)) = moveOriginTo ((-1) *. p) (getEnvelope t)
 
 instance (InnerSpace v, OrderedField (Scalar v)) => Juxtaposable (Path v) where
   juxtapose = juxtaposeDefault
@@ -321,68 +131,71 @@ instance (InnerSpace v, OrderedField (Scalar v)) => Juxtaposable (Path v) where
 instance (InnerSpace v, OrderedField (Scalar v)) => Alignable (Path v) where
   alignBy = alignByDefault
 
-instance HasLinearMap v => Renderable (Path v) NullBackend where
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Renderable (Path v) NullBackend where
   render _ _ = mempty
 
 ------------------------------------------------------------
---  Constructing paths from trails  ------------------------
+--  Constructing paths  ------------------------------------
 ------------------------------------------------------------
+
+-- $construct
+-- Since paths are 'TrailLike', any function producing a 'TrailLike'
+-- can be used to construct a (singleton) path.  The functions in this
+-- section are provided for convenience.
 
 -- | Convert a trail to a path beginning at the origin.
-pathFromTrail :: AdditiveGroup v => Trail v -> Path v
-pathFromTrail t = Path [(origin, t)]
+pathFromTrail :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> Path v
+pathFromTrail = trailLike . (`at` origin)
 
 -- | Convert a trail to a path with a particular starting point.
-pathFromTrailAt :: Trail v -> Point v -> Path v
-pathFromTrailAt t p = Path [(p, t)]
+pathFromTrailAt :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> Point v -> Path v
+pathFromTrailAt t p = trailLike (t `at` p)
+
+-- | Convert a located trail to a singleton path.  This is equivalent
+--   to 'trailLike', but provided with a more specific name and type
+--   for convenience.
+pathFromLocTrail :: (InnerSpace v, OrderedField (Scalar v)) => Located (Trail v) -> Path v
+pathFromLocTrail = trailLike
 
 ------------------------------------------------------------
---  Computing with paths  ----------------------------------
+--  Eliminating paths  -------------------------------------
 ------------------------------------------------------------
 
--- | Extract the vertices of a path.
-pathVertices :: AdditiveGroup v => Path v -> [[Point v]]
-pathVertices = map (uncurry trailVertices) . pathTrails
+-- | Extract the vertices of a path, resulting in a separate list of
+--   vertices for each component trail (see 'trailVertices').
+pathVertices :: (InnerSpace v, OrderedField (Scalar v)) => Path v -> [[Point v]]
+pathVertices = map trailVertices . pathTrails
 
--- | Compute the total offset of each trail comprising a path.
-pathOffsets :: AdditiveGroup v => Path v -> [v]
-pathOffsets = map (trailOffset . snd) . pathTrails
+-- | Compute the total offset of each trail comprising a path (see 'trailOffset').
+pathOffsets :: (InnerSpace v, OrderedField (Scalar v)) => Path v -> [v]
+pathOffsets = map (trailOffset . unLoc) . pathTrails
 
--- | Compute the /centroid/ of a path (/i.e./ the average of its
---   vertices).
-pathCentroid :: (VectorSpace v, Fractional (Scalar v)) => Path v -> Point v
+-- | Compute the /centroid/ of a path (/i.e./ the average location of
+--   its vertices).
+pathCentroid :: (InnerSpace v, OrderedField (Scalar v)) => Path v -> Point v
 pathCentroid = centroid . concat . pathVertices
+
+-- | Convert a path into a list of lists of 'FixedSegment's.
+fixPath :: (InnerSpace v, OrderedField (Scalar v)) => Path v -> [[FixedSegment v]]
+fixPath = map fixTrail . unpack
+
+-- | \"Explode\" a path by exploding every component trail (see
+--   'explodeTrail').
+explodePath :: (VectorSpace (V t), TrailLike t) => Path (V t) -> [[t]]
+explodePath = map explodeTrail . pathTrails
+
+------------------------------------------------------------
+--  Modifying paths  ---------------------------------------
+------------------------------------------------------------
 
 -- | Scale a path using its centroid (see 'pathCentroid') as the base
 --   point for the scale.
-scalePath :: (HasLinearMap v, VectorSpace v, Fractional (Scalar v), Eq (Scalar v))
+scalePath :: (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
           => Scalar v -> Path v -> Path v
 scalePath d p = (scale d `under` translation (origin .-. pathCentroid p)) p
 
--- | Reverse the direction of all the component trails of a path.
-reversePath :: AdditiveGroup v => Path v -> Path v
-reversePath = (over Path . map) reverseRootedTrail
+-- | Reverse all the component trails of a path.
+reversePath :: (InnerSpace v, OrderedField (Scalar v)) => Path v -> Path v
+reversePath = (over Path . map) reverseLocTrail
 
--- | Convert a path into a list of lists of 'FixedSegment's.
-fixPath :: AdditiveGroup v => Path v -> [[FixedSegment v]]
-fixPath = map (uncurry fixTrail) . unpack
-
-------------------------------------------------------------
---  Other functions  ---------------------------------------
-------------------------------------------------------------
-
--- | Given a starting point, \"explode\" a trail by turning each
---   segment (including the implicit closing segment, if the trail is
---   closed) into its own separate path.  Useful for (say) applying a
---   different style to each segment.
-explodeTrail :: (VectorSpace (V p), PathLike p) => Point (V p) -> Trail (V p) -> [p]
-explodeTrail start = snd . mapAccumL mkPath start . trailSegments'
-  where mkPath p seg = (p .+^ segOffset seg, pathLike p False [seg])
-
--- | \"Explode\" a path by exploding every component trail (see 'explodeTrail').
-explodePath :: (VectorSpace (V p), PathLike p) => Path (V p) -> [[p]]
-explodePath = map (uncurry explodeTrail) . pathTrails
-
--- | Create a single-segment path between two given points.
-(~~) :: PathLike p => Point (V p) -> Point (V p) -> p
-p1 ~~ p2 = fromVertices [p1, p2]

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -33,10 +33,19 @@ module Diagrams.Prelude
          -- | Combining multiple diagrams into one.
        , module Diagrams.Combinators
 
+         -- | Giving concrete locations to translation-invariant things.
+       , module Diagrams.Located
+
          -- | Linear and cubic bezier segments.
        , module Diagrams.Segment
 
-         -- | Trails and paths.
+         -- | Trails.
+       , module Diagrams.Trail
+
+         -- | Trail-like things.
+       , module Diagrams.TrailLike
+
+         -- | Paths.
        , module Diagrams.Path
 
          -- | Cubic splines.
@@ -80,25 +89,28 @@ module Diagrams.Prelude
        , Applicative(..), (*>), (<*), (<$>), (<$), liftA, liftA2, liftA3
        ) where
 
-import Diagrams.Core
+import           Diagrams.Core
 
-import Diagrams.Align
-import Diagrams.Animation
-import Diagrams.Attributes
-import Diagrams.BoundingBox
-import Diagrams.Combinators
-import Diagrams.Coordinates
-import Diagrams.CubicSpline
-import Diagrams.Path
-import Diagrams.Segment
-import Diagrams.Transform
-import Diagrams.TwoD
-import Diagrams.Util
+import           Diagrams.Align
+import           Diagrams.Animation
+import           Diagrams.Attributes
+import           Diagrams.BoundingBox
+import           Diagrams.Combinators
+import           Diagrams.Coordinates
+import           Diagrams.CubicSpline
+import           Diagrams.Located
+import           Diagrams.Path
+import           Diagrams.Segment
+import           Diagrams.Trail
+import           Diagrams.TrailLike
+import           Diagrams.Transform
+import           Diagrams.TwoD
+import           Diagrams.Util
 
-import Data.Colour hiding (atop, AffineSpace(..))
-import Data.Colour.Names
-import Data.Semigroup
-import Data.VectorSpace hiding (Sum(..))
-import Data.AffineSpace
-import Data.Active
-import Control.Applicative
+import           Control.Applicative
+import           Data.Active
+import           Data.AffineSpace
+import           Data.Colour          hiding (AffineSpace (..), atop)
+import           Data.Colour.Names
+import           Data.Semigroup
+import           Data.VectorSpace     hiding (Sum (..))

--- a/src/Diagrams/Segment.hs
+++ b/src/Diagrams/Segment.hs
@@ -1,35 +1,50 @@
-{-# LANGUAGE TypeFamilies
-           , FlexibleContexts
-           , FlexibleInstances
-           , MultiParamTypeClasses
-           , DeriveFunctor
-           , UndecidableInstances
-  #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Segment
--- Copyright   :  (c) 2011 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2011-2013 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
--- A /segment/ is a translation-invariant, atomic path.  There are two
--- types: linear (/i.e./ just a straight line to the endpoint) and
--- cubic Bézier curves (/i.e./ a curve to an endpoint with two control
--- points).  This module contains tools for creating and manipulating
--- segments, as well as a definition of segments with a fixed location
--- (useful for backend implementors).
+-- A /segment/ is a translation-invariant, atomic path.  Currently,
+-- there are two types: linear (/i.e./ just a straight line to the
+-- endpoint) and cubic Bézier curves (/i.e./ a curve to an endpoint
+-- with two control points).  This module contains tools for creating
+-- and manipulating segments, as well as a definition of segments with
+-- a fixed location (useful for backend implementors).
 --
 -- Generally speaking, casual users of diagrams should not need this
--- module; the higher-level functionality provided by "Diagrams.Path"
--- should usually suffice instead.  However, directly manipulating
--- segments can occasionally be useful.
+-- module; the higher-level functionality provided by
+-- "Diagrams.Trail", "Diagrams.TrailLike", and "Diagrams.Path" should
+-- usually suffice.  However, directly manipulating segments can
+-- occasionally be useful.
 --
 -----------------------------------------------------------------------------
 
 module Diagrams.Segment
-       ( -- * Constructing segments
+       ( -- * Open/closed tags
 
-         Segment(..), straight, bezier3
+         Open, Closed
+
+         -- * Segment offsets
+
+       , Offset(..)
+
+         -- * Constructing segments
+
+       , Segment(..), straight, bezier3
 
          -- * Computing with segments
        , atParam, segOffset
@@ -50,85 +65,147 @@ module Diagrams.Segment
        , mkFixedSeg, fromFixedSeg
        , fAtParam
 
+         -- * Segment measures
+         -- $segmeas
+
+       , SegCount(..)
+       , ArcLength(..)
+       , TotalOffset(..)
+       , OffsetEnvelope(..)
+       , SegMeasure
+
        ) where
 
-import Diagrams.Core
+import           Control.Applicative (liftA2)
+import           Data.AffineSpace
+import           Data.Default.Class
+import           Data.FingerTree
+import           Data.Monoid.MList
+import           Data.Semigroup
+import           Data.VectorSpace    hiding (Sum)
 
-import Diagrams.Solve
-import Diagrams.Util
+import           Diagrams.Core
+import           Diagrams.Located
+import           Diagrams.Solve
+import           Diagrams.Util
 
-import Data.Default.Class
-import Data.AffineSpace
-import Data.VectorSpace
 
-import Control.Applicative (liftA2)
-import Data.Semigroup
+------------------------------------------------------------
+--  Open/closed type tags  ---------------------------------
+------------------------------------------------------------
+
+-- Eventually we should use DataKinds for this, but not until we drop
+-- support for GHC 7.4.
+
+-- | Type tag for open segments.
+data Open
+
+-- | Type tag for closed segments.
+data Closed
+
+------------------------------------------------------------
+--  Segment offsets  ---------------------------------------
+------------------------------------------------------------
+
+-- | The /offset/ of a segment is the vector from its starting point
+--   to its end.  The offset for an /open/ segment is determined by
+--   the context, /i.e./ its endpoint is not fixed.  The offset for a
+--   /closed/ segment is stored explicitly, /i.e./ its endpoint is at
+--   a fixed offset from its start.
+data Offset c v where
+  OffsetOpen   :: Offset Open v
+  OffsetClosed :: v -> Offset Closed v
+
+deriving instance Show v => Show (Offset c v)
+deriving instance Eq   v => Eq   (Offset c v)
+deriving instance Ord  v => Ord  (Offset c v)
+
+instance Functor (Offset c) where
+  fmap _ OffsetOpen       = OffsetOpen
+  fmap f (OffsetClosed v) = OffsetClosed (f v)
+
+type instance V (Offset c v) = v
+
+instance HasLinearMap v => Transformable (Offset c v) where
+  transform = fmap . apply
 
 ------------------------------------------------------------
 --  Constructing segments  ---------------------------------
 ------------------------------------------------------------
 
--- | The atomic constituents of paths are /segments/, which are single
---   straight lines or cubic Bézier curves.  Segments are
+-- | The atomic constituents of the concrete representation currently
+--   used for trails are /segments/, currently limited to
+--   single straight lines or cubic Bézier curves.  Segments are
 --   /translationally invariant/, that is, they have no particular
 --   \"location\" and are unaffected by translations.  They are,
 --   however, affected by other transformations such as rotations and
 --   scales.
-data Segment v = Linear v     -- ^ A linear segment with given offset.
-               | Cubic v v v  -- ^ A cubic Bézier segment specified by
-                              --   three offsets from the starting
-                              --   point to the first control point,
-                              --   second control point, and ending
-                              --   point, respectively.
+data Segment c v
+    = Linear (Offset c v)
+      -- ^ A linear segment with given offset.
+
+    | Cubic v v (Offset c v)
+      -- ^ A cubic Bézier segment specified by
+      --   three offsets from the starting
+      --   point to the first control point,
+      --   second control point, and ending
+      --   point, respectively.
+
   deriving (Show, Functor, Eq, Ord)
 
-type instance V (Segment v) = v
+-- Note, can't yet have Haddock comments on GADT constructors; see
+-- http://trac.haskell.org/haddock/ticket/43. For now we don't need
+-- Segment to be a GADT but we might in the future. (?)
 
-instance HasLinearMap v => Transformable (Segment v) where
+type instance V (Segment c v) = v
+
+instance HasLinearMap v => Transformable (Segment c v) where
   transform = fmap . apply
 
-instance HasLinearMap v => Renderable (Segment v) NullBackend where
+instance HasLinearMap v => Renderable (Segment c v) NullBackend where
   render _ _ = mempty
 
 -- | @'straight' v@ constructs a translationally invariant linear
 --   segment with direction and length given by the vector @v@.
-straight :: v -> Segment v
-straight = Linear
+straight :: v -> Segment Closed v
+straight = Linear . OffsetClosed
 
 -- Note, if we didn't have a Linear constructor we could also create
 -- linear segments with @Cubic (v ^/ 3) (2 *^ (v ^/ 3)) v@.  Those
 -- would not be precisely the same, however, since we can actually
 -- observe how segments are parametrized.
 
--- | @bezier3 v1 v2 v3@ constructs a translationally invariant cubic
+-- | @bezier3 c1 c2 x@ constructs a translationally invariant cubic
 --   Bézier curve where the offsets from the first endpoint to the
 --   first and second control point and endpoint are respectively
---   given by @v1@, @v2@, and @v3@.
-bezier3 :: v -> v -> v -> Segment v
-bezier3 = Cubic
+--   given by @c1@, @c2@, and @x@.
+bezier3 :: v -> v -> v -> Segment Closed v
+bezier3 c1 c2 x = Cubic c1 c2 (OffsetClosed x)
 
 -- | 'atParam' yields a parametrized view of segments as continuous
 --   functions @[0,1] -> v@, which give the offset from the start of
 --   the segment for each value of the parameter between @0@ and @1@.
 --   It is designed to be used infix, like @seg ``atParam`` 0.5@.
-atParam :: (VectorSpace v, Num (Scalar v)) => Segment v -> Scalar v -> v
-atParam (Linear x) t       = t *^ x
-atParam (Cubic c1 c2 x2) t =     (3 * t'*t'*t ) *^ c1
-                             ^+^ (3 * t'*t *t ) *^ c2
-                             ^+^ (    t *t *t ) *^ x2
+atParam :: (VectorSpace v, Num (Scalar v)) => Segment Closed v -> Scalar v -> v
+atParam (Linear (OffsetClosed x)) t       = t *^ x
+atParam (Cubic c1 c2 (OffsetClosed x2)) t =     (3 * t'*t'*t ) *^ c1
+                                            ^+^ (3 * t'*t *t ) *^ c2
+                                            ^+^ (    t *t *t ) *^ x2
   where t' = 1-t
 
 -- | Compute the offset from the start of a segment to the
 --   end.  Note that in the case of a Bézier segment this is /not/ the
 --   same as the length of the curve itself; for that, see 'arcLength'.
-segOffset :: Segment v -> v
-segOffset (Linear v)    = v
-segOffset (Cubic _ _ v) = v
+segOffset :: Segment Closed v -> v
+segOffset (Linear (OffsetClosed v))    = v
+segOffset (Cubic _ _ (OffsetClosed v)) = v
 
 -- | Reverse the direction of a segment.
-reverseSegment :: AdditiveGroup v => Segment v -> Segment v
-reverseSegment (Linear v)       = Linear (negateV v)
-reverseSegment (Cubic c1 c2 x2) = Cubic (c2 ^-^ x2) (c1 ^-^ x2) (negateV x2)
+reverseSegment :: AdditiveGroup v => Segment Closed v -> Segment Closed v
+reverseSegment (Linear (OffsetClosed v))
+  = Linear (OffsetClosed (negateV v))
+reverseSegment (Cubic c1 c2 (OffsetClosed x2))
+  = Cubic (c2 ^-^ x2) (c1 ^-^ x2) (OffsetClosed (negateV x2))
 
 ------------------------------------------------------------
 --  Computing segment envelope  ------------------------------
@@ -157,12 +234,12 @@ reverseSegment (Cubic c1 c2 x2) = Cubic (c2 ^-^ x2) (c1 ^-^ x2) (negateV x2)
 -}
 
 -- | The envelope for a segment is based at the segment's start.
-instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Segment v) where
+instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Segment Closed v) where
 
   getEnvelope (s@(Linear {})) = mkEnvelope $ \v ->
     maximum . map (\t -> ((s `atParam` t) <.> v) / magnitudeSq v) $ [0,1]
 
-  getEnvelope (s@(Cubic c1 c2 x2)) = mkEnvelope $ \v ->
+  getEnvelope (s@(Cubic c1 c2 (OffsetClosed x2))) = mkEnvelope $ \v ->
     maximum .
     map (\t -> ((s `atParam` t) <.> v) / magnitudeSq v) $
     [0,1] ++
@@ -192,14 +269,14 @@ instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Segment v) where
 --   segments where the first is the original segment extended to the
 --   parameter 2, and the second result segment travels /backwards/
 --   from the end of the first to the end of the original segment.
-splitAtParam :: (VectorSpace v) => Segment v -> Scalar v -> (Segment v, Segment v)
-splitAtParam (Linear x1) t = (left, right)
-  where left  = Linear p
-        right = Linear (x1 ^-^ p)
-        p = lerp zeroV x1 t
-splitAtParam (Cubic c1 c2 x2) t = (left, right)
-  where left  = Cubic a b e
-        right = Cubic (c ^-^ e) (d ^-^ e) (x2 ^-^ e)
+splitAtParam :: (VectorSpace v) => Segment Closed v -> Scalar v -> (Segment Closed v, Segment Closed v)
+splitAtParam (Linear (OffsetClosed x1)) t = (left, right)
+  where left  = straight p
+        right = straight (x1 ^-^ p)
+        p     = lerp zeroV x1 t
+splitAtParam (Cubic c1 c2 (OffsetClosed x2)) t = (left, right)
+  where left  = bezier3 a b e
+        right = bezier3 (c ^-^ e) (d ^-^ e) (x2 ^-^ e)
         p = lerp c1    c2 t
         a = lerp zeroV c1 t
         b = lerp a     p  t
@@ -212,9 +289,9 @@ splitAtParam (Cubic c1 c2 x2) t = (left, right)
 --   by subdividing until the arc length of the path through the control points is
 --   within @m@ of distance from start to end.
 arcLength :: (InnerSpace v, Floating (Scalar v), Ord (Scalar v))
-          => Segment v -> Scalar v -> Scalar v
-arcLength (Linear x1) _ = magnitude x1
-arcLength s@(Cubic c1 c2 x2) m
+          => Segment Closed v -> Scalar v -> Scalar v
+arcLength (Linear (OffsetClosed x1)) _ = magnitude x1
+arcLength s@(Cubic c1 c2 (OffsetClosed x2)) m
   | ub - lb < m = (ub + lb) / 2
   | otherwise   = arcLength l m + arcLength r m
  where (l,r) = splitAtParam s 0.5
@@ -227,7 +304,7 @@ arcLength s@(Cubic c1 c2 x2) m
 --   for /any/ arc length, and may return any parameter value (not
 --   just parameters between 0 and 1).
 arcLengthToParam :: (InnerSpace v, Floating (Scalar v), Ord (Scalar v), AdditiveGroup v)
-                 => Segment v -> Scalar v -> Scalar v -> Scalar v
+                 => Segment Closed v -> Scalar v -> Scalar v -> Scalar v
 arcLengthToParam s _ m | arcLength s m == 0 = 0.5
 arcLengthToParam s@(Linear {}) len m = len / arcLength s m
 arcLengthToParam s@(Cubic {})  len m
@@ -265,9 +342,9 @@ data AdjustSide = Start  -- ^ Adjust only the beginning
   deriving (Show, Read, Eq, Ord, Bounded, Enum)
 
 -- | How should a segment, trail, or path be adjusted?
-data AdjustOpts v = ALO { adjMethod :: AdjustMethod v
-                        , adjSide   :: AdjustSide
-                        , adjEps    :: Scalar v
+data AdjustOpts v = ALO { adjMethod       :: AdjustMethod v
+                        , adjSide         :: AdjustSide
+                        , adjEps          :: Scalar v
                         , adjOptsvProxy__ :: Proxy v
                         }
 
@@ -284,7 +361,7 @@ instance Fractional (Scalar v) => Default (AdjustOpts v) where
 --   option record which controls how the adjustment should be
 --   performed; see 'AdjustOpts'.
 adjustSegment :: (InnerSpace v, OrderedField (Scalar v))
-              => Segment v -> AdjustOpts v -> Segment v
+              => Segment Closed v -> AdjustOpts v -> Segment Closed v
 adjustSegment s opts = adjustSegmentToParams s
     (if adjSide opts == End   then 0 else getParam s)
     (if adjSide opts == Start then 0 else 1 - getParam (reverseSegment s))
@@ -303,7 +380,7 @@ adjustSegment s opts = adjustSegmentToParams s
 --   which lies on the (infinitely extended) original segment
 --   beginning at @t1@ and ending at @t2@.
 adjustSegmentToParams :: (Fractional (Scalar v), VectorSpace v)
-                      => Segment v -> Scalar v -> Scalar v -> Segment v
+                      => Segment Closed v -> Scalar v -> Scalar v -> Segment Closed v
 adjustSegmentToParams s t1 t2 = snd (splitAtParam (fst (splitAtParam s t2)) (t1/t2))
 
 ------------------------------------------------------------
@@ -311,7 +388,10 @@ adjustSegmentToParams s t1 t2 = snd (splitAtParam (fst (splitAtParam s t2)) (t1/
 ------------------------------------------------------------
 
 -- | @FixedSegment@s are like 'Segment's except that they have
---   absolute locations.
+--   absolute locations.  @FixedSegment v@ is isomorphic to @Located
+--   (Segment Closed v)@, as witnessed by 'mkFixedSeg' and
+--   'fromFixedSeg', but @FixedSegment@ is convenient when one needs
+--   the absolute locations of the vertices and control points.
 data FixedSegment v = FLinear (Point v) (Point v)
                     | FCubic (Point v) (Point v) (Point v) (Point v)
   deriving Show
@@ -346,22 +426,24 @@ instance VectorSpace v => HasOrigin (FixedSegment v) where
 
 instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (FixedSegment v) where
   getEnvelope f = moveTo p (getEnvelope s)
-    where (p, s) = fromFixedSeg f
+    where (p, s) = viewLoc $ fromFixedSeg f
 
     -- Eventually we might decide it's cleaner/more efficient (?) to
     -- have all the computation in the FixedSegment instance of
     -- Envelope, and implement the Segment instance in terms of it,
     -- instead of the other way around
 
--- | Create a 'FixedSegment' from a starting point and a 'Segment'.
-mkFixedSeg :: AdditiveGroup v => Point v -> Segment v -> FixedSegment v
-mkFixedSeg p (Linear v)       = FLinear p (p .+^ v)
-mkFixedSeg p (Cubic c1 c2 x2) = FCubic p (p .+^ c1) (p .+^ c2) (p .+^ x2)
+-- | Create a 'FixedSegment' from a located 'Segment'.
+mkFixedSeg :: AdditiveGroup v => Located (Segment Closed v) -> FixedSegment v
+mkFixedSeg (viewLoc -> (p, Linear (OffsetClosed v)))
+  = FLinear p (p .+^ v)
+mkFixedSeg (viewLoc -> (p, Cubic c1 c2 (OffsetClosed x2)))
+  = FCubic  p (p .+^ c1) (p .+^ c2) (p .+^ x2)
 
--- | Decompose a 'FixedSegment' into a starting point and a 'Segment'.
-fromFixedSeg :: AdditiveGroup v => FixedSegment v -> (Point v, Segment v)
-fromFixedSeg (FLinear p1 p2)      = (p1, Linear (p2 .-. p1))
-fromFixedSeg (FCubic x1 c1 c2 x2) = (x1, Cubic (c1 .-. x1) (c2 .-. x1) (x2 .-. x1))
+-- | Convert a 'FixedSegment' back into a located 'Segment'.
+fromFixedSeg :: AdditiveGroup v => FixedSegment v -> Located (Segment Closed v)
+fromFixedSeg (FLinear p1 p2)      = straight (p2 .-. p1) `at` p1
+fromFixedSeg (FCubic x1 c1 c2 x2) = bezier3 (c1 .-. x1) (c2 .-. x1) (x2 .-. x1) `at` x1
 
 -- | Compute the point on a fixed segment at a given parameter.  A
 --   parameter of 0 corresponds to the starting point and 1 corresponds
@@ -377,3 +459,66 @@ fAtParam (FCubic x1 c1 c2 x2) t = p3
         p22 = alerp p12 p13 t
 
         p3  = alerp p21 p22 t
+
+------------------------------------------------------------
+--  Segment measures  --------------------------------------
+------------------------------------------------------------
+
+-- $segmeas
+-- Trails store a sequence of segments in a fingertree, which can
+-- automatically track various monoidal \"measures\" on segments.
+
+-- | A type to track the count of segments in a 'Trail'.
+newtype SegCount = SegCount { getSegCount :: Sum Int }
+  deriving (Semigroup, Monoid)
+
+-- | A type to represent the total arc length of a chain of segments.
+newtype ArcLength v = ArcLength { getArcLength :: Sum (Scalar v) }
+
+deriving instance (Num (Scalar v)) => Semigroup (ArcLength v)
+deriving instance (Num (Scalar v)) => Monoid    (ArcLength v)
+
+-- | A type to represent the total cumulative offset of a chain of
+--   segments.
+newtype TotalOffset v = TotalOffset { getTotalOffset :: v }
+
+instance AdditiveGroup v => Semigroup (TotalOffset v) where
+  TotalOffset v1 <> TotalOffset v2 = TotalOffset (v1 ^+^ v2)
+
+instance AdditiveGroup v => Monoid (TotalOffset v) where
+  mempty  = TotalOffset zeroV
+  mappend = (<>)
+
+-- | A type to represent the offset and envelope of a chain of
+--   segments.  They have to be paired into one data structure, since
+--   combining the envelopes of two consecutive chains needs to take
+--   the offset of the the offset of the first into account.
+data OffsetEnvelope v = OffsetEnvelope
+  { oeOffset   :: TotalOffset v
+  , oeEnvelope :: Envelope v
+  }
+
+instance (InnerSpace v, OrderedField (Scalar v)) => Semigroup (OffsetEnvelope v) where
+  (OffsetEnvelope o1 e1) <> (OffsetEnvelope o2 e2)
+    = OffsetEnvelope
+        (o1 <> o2)
+        (e1 <> moveOriginBy (negateV . getTotalOffset $ o1) e2)
+
+-- | @SegMeasure@ collects up all the measurements over a chain of
+--   segments.
+type SegMeasure v = SegCount
+                ::: ArcLength v
+                ::: OffsetEnvelope v
+                ::: ()
+  -- unfortunately we can't cache Trace, since there is not a generic
+  -- instance Traced (Segment Closed v), only Traced (Segment Closed R2).
+
+instance (OrderedField (Scalar v), InnerSpace v)
+    => Measured (SegMeasure v) (Segment Closed v) where
+  measure s = (SegCount . Sum $ 1)
+           *: (ArcLength . Sum $ arcLength s 10e-6)  -- XXX what tolerance to use?
+           *: (OffsetEnvelope
+                (TotalOffset . segOffset $ s)
+                (getEnvelope s)
+              )
+           *: ()

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -1,0 +1,627 @@
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams.Trail
+-- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- This module defines /trails/, translationally invariant paths
+-- through space.  Trails form a central part of the diagrams-lib API,
+-- so the documentation for this module merits careful study.
+--
+-- Related modules include:
+--
+-- * The 'TrailLike' class ("Diagrams.TrailLike") exposes a generic
+--   API for building a wide range of things out of trails.
+--
+-- * 'Path's ("Diagrams.Path") are collections of 'Located'
+--   ("Diagrams.Located") trails.
+--
+-- * Trails are composed of 'Segment's (see "Diagrams.Segment"),
+--   though most users should not need to work with segments directly.
+--
+-----------------------------------------------------------------------------
+
+module Diagrams.Trail
+       (
+         -- * Type definitions
+
+         -- ** Lines and loops
+
+         Trail'(..)
+
+       , glueLine
+       , closeLine
+       , cutLoop
+
+         -- ** Generic trails
+
+       , Trail(..)
+       , wrapTrail, wrapLine, wrapLoop
+       , onTrail, onLine
+
+       , glueTrail, closeTrail, cutTrail
+
+         -- * Constructing trails
+
+       , emptyLine, emptyTrail
+       , lineFromVertices, trailFromVertices
+       , lineFromOffsets,  trailFromOffsets
+       , lineFromSegments, trailFromSegments
+
+         -- * Eliminating trails
+
+       , withTrail', withTrail, withLine
+       , isLoop
+       , trailSegments, lineSegments, loopSegments
+       , trailOffsets, trailOffset
+       , lineOffsets, lineOffset, loopOffsets
+       , trailVertices, lineVertices, loopVertices
+       , fixTrail
+
+         -- * Modifying trails
+
+       , reverseTrail, reverseLocTrail
+       , reverseLine, reverseLocLine
+       , reverseLoop, reverseLocLoop
+
+         -- * Internals
+         -- $internals
+
+         -- ** Type tags
+
+       , Line, Loop
+
+         -- ** Segment trees
+
+       , SegTree(..), trailMeasure
+
+       ) where
+
+import           Data.AffineSpace
+import           Data.FingerTree   (FingerTree, ViewR (..), (|>))
+import qualified Data.FingerTree   as FT
+import qualified Data.Foldable     as F
+import           Data.Monoid.MList
+import           Data.Semigroup
+import           Data.VectorSpace
+
+import           Diagrams.Core     hiding ((|>))
+import           Diagrams.Located
+import           Diagrams.Segment
+
+-- $internals
+--
+-- Most users of diagrams should not need to use anything in this
+-- section directly, but they are exported on the principle that we
+-- can't forsee what uses people might have for them.
+
+------------------------------------------------------------
+--  Segment trees  -----------------------------------------
+------------------------------------------------------------
+
+-- | A @SegTree@ represents a sequence of closed segments, stored in a
+--   fingertree so we can easily recover various monoidal measures of
+--   the segments (number of segments, arc length, envelope...) and
+--   also easily slice and dice them according to the measures
+--   (/e.g./, split off the smallest number of segments from the
+--   beginning which have a combined arc length of at least 5).
+newtype SegTree v = SegTree
+                  { getSegTree :: FingerTree (SegMeasure v) (Segment Closed v) }
+  deriving (Eq, Ord, Show)
+
+deriving instance (OrderedField (Scalar v), InnerSpace v) => Monoid (SegTree v)
+deriving instance (OrderedField (Scalar v), InnerSpace v) => FT.Measured (SegMeasure v) (SegTree v)
+
+type instance V (SegTree v) = v
+
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Transformable (SegTree v) where
+  transform tr (SegTree t) = SegTree (FT.fmap' (transform tr) t)
+
+-- | Given a default result (to be used in the case of an empty
+--   trail), and a function to map a single measure to a result,
+--   extract the given measure for a trail and use it to compute a
+--   result.  Put another way, lift a function on a single measure
+--   (along with a default value) to a function on an entire trail.
+trailMeasure :: ( InnerSpace v, OrderedField (Scalar v)
+                , SegMeasure v :>: m, FT.Measured (SegMeasure v) t
+                )
+             => a -> (m -> a) -> t -> a
+trailMeasure d f = option d f . get . FT.measure
+
+------------------------------------------------------------
+--  Trails  ------------------------------------------------
+------------------------------------------------------------
+
+-- Eventually we should use DataKinds for this, but not until we drop
+-- support for GHC 7.4.
+
+-- | Type tag for trails with distinct endpoints.
+data Line
+
+-- | Type tag for \"loopy\" trails which return to their starting
+--   point.
+data Loop
+
+--------------------------------------------------
+-- The Trail' type
+
+-- XXX add some pictures?
+
+-- | Intuitively, a trail is a single, continuous path through space.
+--   However, a trail has no fixed starting point; it merely specifies
+--   /how/ to move through space, not /where/.  For example, \"take
+--   three steps forward, then turn right twenty degrees and take two
+--   more steps\" is an intuitive analog of a trail; these
+--   instructions specify a path through space from any given starting
+--   location.  To be precise, trails are /translation-invariant/;
+--   applying a translation to a trail has no effect.
+--
+--   A @'Located' Trail@, on the other hand, is a trail paired with
+--   some concrete starting location (\"start at the big tree on the
+--   corner, then take three steps forward, ...\").  See the
+--   "Diagrams.Located" module for help working with 'Located' values.
+--
+--   Formally, the semantics of a trail is a continuous (though not
+--   necessarily differentiable) function from the real interval [0,1]
+--   to vectors in some vector space.  (In contrast, a 'Located' trail
+--   is a continuous function from [0,1] to /points/ in some /affine/
+--   space.)
+--
+--   There are two types of trails:
+--
+--   * A \"line\" (think of the \"train\", \"subway\", or \"bus\"
+--     variety, rather than the \"straight\" variety...) is a trail
+--     with two distinct endpoints.  Actually, a line can have the
+--     same start and end points, but it is still /drawn/ as if it had
+--     distinct endpoints: the two endpoints will have the appropriate
+--     end caps, and the trail will not be filled.  Lines have a
+--     @Monoid@ instance where @mappend@ corresponds to concatenation,
+--     /i.e./ chaining one line after the other.
+--
+--   * A \"loop\" is required to end in the same place it starts (that
+--     is, t(0) = t(1)).  Loops are filled and are drawn as one
+--     continuous loop, with the appropriate join at the
+--     start/endpoint rather than end caps.  Loops do not have a
+--     @Monoid@ instance.
+--
+--   To convert between lines and loops, see 'glueLine',
+--   'closeLine', and 'cutLoop'.
+--
+--   To construct trails, see 'emptyTrail', 'trailFromSegments',
+--   'trailFromVertices', 'trailFromOffsets', and friends.  You can
+--   also get any type of trail from any function which returns a
+--   'TrailLike' (/e.g./ functions in "Diagrams.TwoD.Shapes", and many
+--   others; see "Diagrams.TrailLike").
+--
+--   To extract information from trails, see 'withLine', 'isLoop',
+--   'trailSegments', 'trailOffsets', 'trailVertices', and friends.
+
+data Trail' l v where
+  Line :: SegTree v                   -> Trail' Line v
+  Loop :: SegTree v -> Segment Open v -> Trail' Loop v
+
+-- | A generic eliminator for 'Trail'', taking functions specifying
+--   what to do in the case of a line or a loop.
+withTrail' :: (Trail' Line v -> r) -> (Trail' Loop v -> r) -> Trail' l v -> r
+withTrail' line loop t@(Line{}) = line t
+withTrail' line loop t@(Loop{}) = loop t
+
+deriving instance Show v => Show (Trail' l v)
+deriving instance Eq   v => Eq   (Trail' l v)
+deriving instance Ord  v => Ord  (Trail' l v)
+
+type instance V (Trail' l v) = v
+
+instance (OrderedField (Scalar v), InnerSpace v) => Semigroup (Trail' Line v) where
+  (Line t1) <> (Line t2) = Line (t1 `mappend` t2)
+
+-- | The empty trail is constantly the zero vector.  Trails are
+--   composed via concatenation.  Note that only lines have a monoid
+--   instance (and not loops).
+instance (OrderedField (Scalar v), InnerSpace v) => Monoid (Trail' Line v) where
+  mempty  = emptyLine
+  mappend = (<>)
+
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Transformable (Trail' l v) where
+  transform tr (Line t  ) = Line (transform tr t)
+  transform tr (Loop t s) = Loop (transform tr t) (transform tr s)
+
+-- | The envelope for a trail is based at the trail's start.
+instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Trail' l v) where
+  getEnvelope = withTrail' ftEnv (ftEnv . cutLoop)
+    where
+      ftEnv (Line t) = trailMeasure mempty oeEnvelope $ t
+
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Renderable (Trail' o v) NullBackend where
+  render _ _ = mempty
+
+--------------------------------------------------
+-- The Trail type
+
+-- | @Trail@ is a wrapper around @Trail'@, hiding whether the
+--   underlying @Trail'@ is a line or loop (though which it is can be
+--   recovered; see /e.g./ 'withTrail').
+data Trail v where
+  Trail :: Trail' l v -> Trail v
+
+deriving instance Show v => Show (Trail v)
+
+instance Eq v => Eq (Trail v) where
+  t1 == t2 =
+    withTrail
+      (\ln1 -> withTrail (\ln2 -> ln1 == ln2) (const False) t2)
+      (\lp1 -> withTrail (const False) (\lp2 -> lp1 == lp2) t2)
+      t1
+
+instance Ord v => Ord (Trail v) where
+  compare t1 t2 =
+    withTrail
+      (\ln1 -> withTrail (\ln2 -> compare ln1 ln2) (const LT) t2)
+      (\lp1 -> withTrail (const GT) (\lp2 -> compare lp1 lp2) t2)
+      t1
+
+type instance V (Trail v) = v
+
+instance (HasLinearMap v, InnerSpace v, OrderedField (Scalar v))
+    => Transformable (Trail v) where
+  transform t = onTrail (transform t) (transform t)
+
+instance (InnerSpace v, OrderedField (Scalar v)) => Enveloped (Trail v) where
+  getEnvelope = withTrail getEnvelope getEnvelope
+
+-- | A generic eliminator for 'Trail', taking functions specifying
+--   what to do in the case of a line or a loop.
+withTrail :: (Trail' Line v -> r) -> (Trail' Loop v -> r) -> Trail v -> r
+withTrail line loop (Trail t) = withTrail' line loop t
+
+-- | Modify a @Trail@, specifying two separate transformations for the
+--   cases of a line or a loop.
+onTrail :: (Trail' Line v -> Trail' l1 v) -> (Trail' Loop v -> Trail' l2 v)
+        -> (Trail v -> Trail v)
+onTrail o c = withTrail (wrapTrail . o) (wrapTrail . c)
+
+-- | An eliminator for @Trail@ based on eliminating lines: if the
+--   trail is a line, the given function is applied; if it is a loop, it
+--   is first converted to a line with 'cutLoop'.  That is,
+--
+-- @
+-- withLine f === 'withTrail' f (f . 'cutLoop')
+-- @
+withLine :: (InnerSpace v, OrderedField (Scalar v))
+              => (Trail' Line v -> r) -> Trail v -> r
+withLine f = withTrail f (f . cutLoop)
+
+-- | Modify a @Trail@ by specifying a transformation on lines.  If the
+--   trail is a line, the transformation will be applied directly.  If
+--   it is a loop, it will first be cut using 'cutLoop', the
+--   transformation applied, and then glued back into a loop with
+--   'glueLine'.  That is,
+--
+--   > onLine f === onTrail f (glueLine . f . cutLoop)
+--
+--   Note that there is no corresponding @onLoop@ function, because
+--   there is no nice way in general to convert a line into a loop,
+--   operate on it, and then convert back.
+onLine :: (InnerSpace v, OrderedField (Scalar v))
+            => (Trail' Line v -> Trail' Line v) -> Trail v -> Trail v
+onLine f = onTrail f (glueLine . f . cutLoop)
+
+-- | Convert a 'Trail'' into a 'Trail', hiding the type-level
+--   distinction between lines and loops.
+wrapTrail :: Trail' l v -> Trail v
+wrapTrail = Trail
+
+-- | Convert a line into a 'Trail'.  This is the same as 'wrapTrail',
+--   but with a more specific type, which can occasionally be
+--   convenient for fixing the type of a polymorphic expression.
+wrapLine :: Trail' Line v -> Trail v
+wrapLine = wrapTrail
+
+-- | Convert a loop into a 'Trail'.  This is the same as 'wrapTrail',
+--   but with a more specific type, which can occasionally be
+--   convenient for fixing the type of a polymorphic expression.
+wrapLoop :: Trail' Loop v -> Trail v
+wrapLoop = wrapTrail
+
+------------------------------------------------------------
+--  Constructing trails  -----------------------------------
+------------------------------------------------------------
+
+-- | The empty line, which is the identity for concatenation of lines.
+emptyLine :: (InnerSpace v, OrderedField (Scalar v)) => Trail' Line v
+emptyLine = Line mempty
+
+-- | A wrapped variant of 'emptyLine'.
+emptyTrail :: (InnerSpace v, OrderedField (Scalar v)) => Trail v
+emptyTrail = wrapLine emptyLine
+
+-- | Construct a line from a list of closed segments.
+lineFromSegments :: (InnerSpace v, OrderedField (Scalar v))
+                   => [Segment Closed v] -> Trail' Line v
+lineFromSegments = Line . SegTree . FT.fromList
+
+-- | @trailFromSegments === 'wrapTrail' . 'lineFromSegments'@, for
+--   conveniently constructing a @Trail@ instead of a @Trail'@.
+trailFromSegments :: (InnerSpace v, OrderedField (Scalar v))
+                  => [Segment Closed v] -> Trail v
+trailFromSegments = wrapTrail . lineFromSegments
+
+-- | Construct a line containing only linear segments from a list of
+--   vectors, where each vector represents the offset from one vertex
+--   to the next.
+--
+--   XXX picture
+lineFromOffsets :: (InnerSpace v, OrderedField (Scalar v))
+                  => [v] -> Trail' Line v
+lineFromOffsets = lineFromSegments . map straight
+
+-- | @trailFromOffsets === 'wrapTrail' . 'lineFromOffsets'@, for
+--   conveniently constructing a @Trail@ instead of a @Trail' Line@.
+trailFromOffsets :: (InnerSpace v, OrderedField (Scalar v))
+                 => [v] -> Trail v
+trailFromOffsets = wrapTrail . lineFromOffsets
+
+-- | Construct a line containing only linear segments from a list of
+--   vertices.  Note that only the relative offsets between the
+--   vertices matters; the information about their absolute position
+--   will be discarded.  That is, for all vectors @v@,
+--
+-- @
+-- lineFromVertices === lineFromVertices . 'translate' v
+-- @
+--
+--   If you want to retain the position information, you should
+--   instead use the more general 'fromVertices' function to
+--   construct, say, a @'Located' ('Trail'' 'Line' v)@ or a @'Located'
+--   ('Trail' v)@.
+--
+--   XXX picture
+lineFromVertices :: (InnerSpace v, OrderedField (Scalar v))
+                   => [Point v] -> Trail' Line v
+lineFromVertices []  = emptyLine
+lineFromVertices [_] = emptyLine
+lineFromVertices ps  = lineFromSegments . map straight $ zipWith (.-.) (tail ps) ps
+
+
+-- | @trailFromVertices === 'wrapTrail' . 'lineFromVertices'@, for
+--   conveniently constructing a @Trail@ instead of a @Trail' Line@.
+trailFromVertices :: (InnerSpace v, OrderedField (Scalar v))
+                  => [Point v] -> Trail v
+trailFromVertices = wrapTrail . lineFromVertices
+
+------------------------------------------------------------
+--  Converting between lines and loops  --------------------
+------------------------------------------------------------
+
+-- | Make a line into a loop by \"gluing\" the endpoint to the
+--   starting point.  In particular, the offset of the final segment
+--   is modified so that it ends at the starting point of the entire
+--   trail.  Typically, you would first construct a line which you
+--   know happens to end where it starts, and then call 'glueLine' to
+--   turn it into a loop.
+--
+--   XXX include some pictures
+--
+--   @glueLine@ is left inverse to 'cutLoop', that is,
+--
+--   > glueLine . cutLoop === id
+glueLine :: (InnerSpace v, OrderedField (Scalar v)) => Trail' Line v -> Trail' Loop v
+glueLine (Line (SegTree t)) =
+  case FT.viewr t of
+    FT.EmptyR             -> Loop mempty (Linear OffsetOpen)
+    t' :> (Linear _)      -> Loop (SegTree t') (Linear OffsetOpen)
+    t' :> (Cubic c1 c2 _) -> Loop (SegTree t') (Cubic c1 c2 OffsetOpen)
+
+-- | @glueTrail@ is a variant of 'glueLine' which works on 'Trail's.
+--   It performs 'glueLine' on lines and is the identity on loops.
+glueTrail :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> Trail v
+glueTrail = onTrail glueLine id
+
+-- | Make a line into a loop by adding a new linear segment from the
+--   line's end to its start.
+--
+--   @closeLine@ does not have any particularly nice theoretical
+--   properties, but can be useful /e.g./ when you want to make a
+--   closed polygon out of a list of points where the initial point is
+--   not repeated at the end.  To use 'glueLine', one would first have
+--   to duplicate the initial vertex, like
+--
+-- @
+-- 'glueLine' . 'lineFromVertices' $ ps ++ [head ps]
+-- @
+--
+--   Using @closeLine@, however, one can simply
+--
+-- @
+-- closeLine . lineFromVertices $ ps
+-- @
+--
+--   XXX include some pictures
+closeLine :: Trail' Line v -> Trail' Loop v
+closeLine (Line t) = Loop t (Linear OffsetOpen)
+
+-- | @closeTrail@ is a variant of 'closeLine' for 'Trail', which
+--   performs 'closeLine' on lines and is the identity on loops.
+closeTrail :: Trail v -> Trail v
+closeTrail = onTrail closeLine id
+
+-- | Turn a loop into a line by \"cutting\" it at the common start/end
+--   point, resulting in a line which just happens to start and end at
+--   the same place.
+--
+--   @cutLoop@ is right inverse to 'glueLine', that is,
+--
+--   > glueLine . cutLoop === id
+--
+--   XXX pictures
+cutLoop :: forall v. (InnerSpace v, OrderedField (Scalar v))
+         => Trail' Loop v -> Trail' Line v
+cutLoop (Loop (SegTree t) c) =
+  case (FT.null t, c) of
+    (True, Linear OffsetOpen)      -> emptyLine
+    (_   , Linear OffsetOpen)      -> Line (SegTree (t |> Linear off))
+    (_   , Cubic c1 c2 OffsetOpen) -> Line (SegTree (t |> Cubic c1 c2 off))
+  where
+    offV :: v
+    offV = negateV . trailMeasure zeroV (getTotalOffset . oeOffset) $ t
+    off = OffsetClosed offV
+
+-- | @cutTrail@ is a variant of 'cutLoop' for 'Trail'; it is the is
+--   the identity on lines and performs 'cutLoop' on loops.
+cutTrail :: (InnerSpace v, OrderedField (Scalar v))
+         => Trail v -> Trail v
+cutTrail = onTrail id cutLoop
+
+------------------------------------------------------------
+--  Eliminating trails  ------------------------------------
+------------------------------------------------------------
+
+-- | Determine whether a trail is a loop.
+isLoop :: Trail v -> Bool
+isLoop = withTrail (const False) (const True)
+
+-- | Extract the segments comprising a line.
+lineSegments :: Trail' Line v -> [Segment Closed v]
+lineSegments (Line (SegTree t)) = F.toList t
+
+-- | Extract the segments comprising a loop: a list of closed
+--   segments, and one final open segment.
+loopSegments :: Trail' Loop v -> ([Segment Closed v], Segment Open v)
+loopSegments (Loop (SegTree t) c) = (F.toList t, c)
+
+-- | Extract the segments of a trail.  If the trail is a loop it will
+--   first have 'cutLoop' applied.
+trailSegments :: (InnerSpace v, OrderedField (Scalar v))
+              => Trail v -> [Segment Closed v]
+trailSegments = withLine lineSegments
+
+-- | Extract the offsets of the segments of a trail.
+trailOffsets :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> [v]
+trailOffsets = withLine lineOffsets
+
+-- | Compute the offset from the start of a trail to the end.  Satisfies
+--
+--   > trailOffset === sumV . trailOffsets
+--
+--   but is more efficient.
+--
+--   XXX picture?
+trailOffset :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> v
+trailOffset = withLine lineOffset
+
+-- | Extract the offsets of the segments of a line.
+lineOffsets :: (InnerSpace v, OrderedField (Scalar v)) => Trail' Line v -> [v]
+lineOffsets = map segOffset . lineSegments
+
+-- | Extract the offsets of the segments of a loop.
+loopOffsets :: (InnerSpace v, OrderedField (Scalar v)) => Trail' Loop v -> [v]
+loopOffsets = lineOffsets . cutLoop
+
+-- | Compute the offset from the start of a line to the end.  (Note,
+--   there is no corresponding @loopOffset@ function because by
+--   definition it would be constantly zero.)
+lineOffset :: (InnerSpace v, OrderedField (Scalar v)) => Trail' Line v -> v
+lineOffset (Line t) = trailMeasure zeroV (getTotalOffset . oeOffset) t
+
+-- | Extract the vertices of a concretely located trail.  Note that
+--   for loops, the starting vertex will /not/ be repeated at the end.
+--   If you want this behavior, you can use 'cutTrail' to make the
+--   loop into a line first, which happens to repeat the same vertex
+--   at the start and end, /e.g./ with @trailVertices . mapLoc
+--   cutTrail@.
+--
+--   Note that it does not make sense to ask for the vertices of a
+--   'Trail' by itself; if you want the vertices of a trail
+--   with the first vertex at, say, the origin, you can use
+--   @trailVertices . (`at` origin)@.
+trailVertices :: (InnerSpace v, OrderedField (Scalar v))
+              => Located (Trail v) -> [Point v]
+trailVertices (viewLoc -> (p,t))
+  = withTrail (lineVertices . (`at` p)) (loopVertices . (`at` p)) t
+
+-- | Extract the vertices of a concretely located line.  See
+--   'trailVertices' for more information.
+lineVertices :: (InnerSpace v, OrderedField (Scalar v))
+             => Located (Trail' Line v) -> [Point v]
+lineVertices (viewLoc -> (p,t))
+  = segmentVertices p . lineSegments $ t
+
+-- | Extract the vertices of a concretely located loop.  Note that the
+--   initial vertex is not repeated at the end.  See 'trailVertices' for
+--   more information.
+loopVertices :: (InnerSpace v, OrderedField (Scalar v))
+             => Located (Trail' Loop v) -> [Point v]
+loopVertices (viewLoc -> (p,t))
+  = segmentVertices p . fst . loopSegments $ t
+
+segmentVertices :: AdditiveGroup v => Point v -> [Segment Closed v] -> [Point v]
+segmentVertices p = scanl (.+^) p . map segOffset
+
+-- | Convert a concretely located trail into a list of fixed segments.
+fixTrail :: (InnerSpace v, OrderedField (Scalar v))
+         => Located (Trail v) -> [FixedSegment v]
+fixTrail t = zipWith ((mkFixedSeg .) . at)
+               (trailSegments (unLoc t)) (trailVertices t)
+
+------------------------------------------------------------
+--  Modifying trails  --------------------------------------
+------------------------------------------------------------
+
+-- | Reverse a trail.  Semantically, if a trail given by a function t
+--   from [0,1] to vectors, then the reverse of t is given by t'(s) =
+--   t(1-s).  @reverseTrail@ is an involution, that is,
+--
+--   > reverseTrail . reverseTrail === id
+reverseTrail :: (InnerSpace v, OrderedField (Scalar v)) => Trail v -> Trail v
+reverseTrail = onTrail reverseLine reverseLoop
+
+-- | Reverse a concretely located trail.  The endpoint of the original
+--   trail becomes the starting point of the reversed trail, so the
+--   original and reversed trails comprise exactly the same set of
+--   points.  @reverseLocTrail@ is an involution, /i.e./
+--
+--   > reverseLocTrail . reverseLocTrail === id
+reverseLocTrail :: (InnerSpace v, OrderedField (Scalar v))
+                => Located (Trail v) -> Located (Trail v)
+reverseLocTrail (viewLoc -> (p, t)) = reverseTrail t `at` (p .+^ trailOffset t)
+
+-- | Reverse a line.  See 'reverseTrail'.
+reverseLine :: (InnerSpace v, OrderedField (Scalar v))
+            => Trail' Line v -> Trail' Line v
+reverseLine = lineFromSegments
+            . reverse
+            . map reverseSegment
+            . lineSegments
+
+-- | Reverse a concretely located line.  See 'reverseLocTrail'.
+reverseLocLine :: (InnerSpace v, OrderedField (Scalar v))
+               => Located (Trail' Line v) -> Located (Trail' Line v)
+reverseLocLine (viewLoc -> (p,l)) = reverseLine l `at` (p .+^ lineOffset l)
+
+-- | Reverse a loop.  See 'reverseTrail'.
+reverseLoop :: (InnerSpace v, OrderedField (Scalar v))
+            => Trail' Loop v -> Trail' Loop v
+reverseLoop = glueLine . reverseLine . cutLoop
+
+-- | Reverse a concretely located loop.  See 'reverseLocTrail'.  Note
+--   that this is guaranteed to preserve the location.
+reverseLocLoop :: (InnerSpace v, OrderedField (Scalar v))
+               => Located (Trail' Loop v) -> Located (Trail' Loop v)
+reverseLocLoop = mapLoc reverseLoop

--- a/src/Diagrams/TrailLike.hs
+++ b/src/Diagrams/TrailLike.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams.TrailLike
+-- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- The 'TrailLike' class abstracts over anything which can be
+-- constructed from a concretely located 'Trail', including
+-- lines, loops, trails, paths, vertex lists, and diagrams.
+--
+-----------------------------------------------------------------------------
+
+module Diagrams.TrailLike
+       (
+         -- * The TrailLike class
+
+         TrailLike(..)
+
+         -- * Constructing TrailLikes
+
+       , fromSegments, fromLocSegments, fromOffsets, fromLocOffsets, fromVertices
+       , (~~), explodeTrail
+
+       ) where
+
+import           Data.AffineSpace ((.-.))
+import           Data.VectorSpace
+
+import           Diagrams.Core
+import           Diagrams.Located
+import           Diagrams.Segment
+import           Diagrams.Trail
+
+------------------------------------------------------------
+--  TrailLike class
+------------------------------------------------------------
+
+-- | A type class for trail-like things, /i.e./ things which can be
+--   constructed from a concretely located 'Trail'.  Instances include
+--   lines, loops, trails, paths, lists of vertices, two-dimensional
+--   'Diagram's, and 'Located' variants of all the above.
+--
+--   Usually, type variables with 'TrailLike' constraints are used as
+--   the /output/ types of functions, like
+--
+--   > foo :: (TrailLike t) => ... -> t
+--
+--   Functions with such a type can be used to construct trails,
+--   paths, diagrams, lists of points, and so on, depending on the
+--   context.
+--
+--   To write a function with a signature like the above, you can of
+--   course call 'trailLike' directly; more typically, one would use
+--   one of the provided functions like 'fromOffsets', 'fromVertices',
+--   'fromSegments', or '~~'.
+class (InnerSpace (V t), OrderedField (Scalar (V t))) => TrailLike t where
+
+  trailLike
+    :: Located (Trail (V t))  -- ^ The concretely located trail.  Note
+                              --   that some trail-like things
+                              --   (e.g. 'Trail's) may ignore the
+                              --   location.
+    -> t
+
+------------------------------------------------------------
+--  Instances  ---------------------------------------------
+
+-- | A list of points is trail-like; this instance simply
+--   computes the vertices of the trail, using 'trailVertices'.
+instance (InnerSpace v, OrderedField (Scalar v)) => TrailLike [Point v] where
+  trailLike = trailVertices
+
+-- | Lines are trail-like.  If given a 'Trail' which contains a loop,
+--   the loop will be cut with 'cutLoop'.  The location is ignored.
+instance (InnerSpace v, OrderedField (Scalar v)) => TrailLike (Trail' Line v) where
+  trailLike = withTrail id cutLoop . unLoc
+
+-- | Loops are trail-like.  If given a 'Trail' containing a line, the
+--   line will be turned into a loop using 'glueLine'.  The location
+--   is ignored.
+instance (InnerSpace v, OrderedField (Scalar v)) => TrailLike (Trail' Loop v) where
+  trailLike = withTrail glueLine id . unLoc
+
+-- | 'Trail's are trail-like; the location is simply ignored.
+instance (InnerSpace v, OrderedField (Scalar v)) => TrailLike (Trail v) where
+  trailLike = unLoc
+
+-- | Translationally invariant things are trail-like as long as the
+--   underlying type is.
+instance TrailLike t => TrailLike (TransInv t) where
+  trailLike = TransInv . trailLike
+
+-- | 'Located' things are trail-like as long as the underlying type
+--   is.  The location is taken to be the location of the input
+--   located trail.
+instance TrailLike t => TrailLike (Located t) where
+  trailLike t = trailLike t `at` loc t
+
+------------------------------------------------------------
+--  Constructing TrailLike things  -------------------------
+------------------------------------------------------------
+
+-- | Construct a trail-like thing from a list of segments, with the
+--   origin as the location.
+--
+--   XXX example/picture
+fromSegments :: TrailLike t => [Segment Closed (V t)] -> t
+fromSegments = fromLocSegments . (`at` origin)
+
+-- | Construct a trail-like thing from a located list of segments.
+fromLocSegments :: TrailLike t => Located [Segment Closed (V t)] -> t
+fromLocSegments = trailLike . mapLoc trailFromSegments
+
+-- | Construct a trail-like thing of linear segments from a list
+--   of offsets, with the origin as the location.
+--
+--   XXX example/picture
+fromOffsets :: TrailLike t => [V t] -> t
+fromOffsets = trailLike . (`at` origin) . trailFromOffsets
+
+-- | Construct a trail-like thing of linear segments from a located
+--   list of offsets.
+fromLocOffsets :: (V (V t) ~ V t, TrailLike t) => Located [V t] -> t
+fromLocOffsets = trailLike . mapLoc trailFromOffsets
+
+-- | Construct a trail-like thing connecting the given vertices with
+--   linear segments, with the first vertex as the location.  If no
+--   vertices are given, the empty trail is used with the origin as
+--   the location.
+--
+--   XXX example/picture
+fromVertices :: TrailLike t => [Point (V t)] -> t
+fromVertices []       = trailLike (emptyTrail `at` origin)
+fromVertices ps@(p:_) = trailLike (trailFromSegments (segmentsFromVertices ps) `at` p)
+
+segmentsFromVertices :: AdditiveGroup v => [Point v] -> [Segment Closed v]
+segmentsFromVertices []         = []
+segmentsFromVertices vvs@(_:vs) = map straight (zipWith (flip (.-.)) vvs vs)
+
+-- | Create a linear trail between two given points.
+(~~) :: TrailLike t => Point (V t) -> Point (V t) -> t
+p1 ~~ p2 = fromVertices [p1, p2]
+
+-- | Given a concretely located trail, \"explode\" it by turning each
+--   segment into its own separate trail.  Useful for (say) applying a
+--   different style to each segment.
+explodeTrail :: (VectorSpace (V t), TrailLike t) => Located (Trail (V t)) -> [t]
+explodeTrail = map (mkTrail . fromFixedSeg) . fixTrail
+  where
+    mkTrail = trailLike . mapLoc (trailFromSegments . (:[]))

--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleContexts, TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD
@@ -92,7 +94,7 @@ module Diagrams.TwoD
        , wedge
 
          -- ** General polygons
-       , polygon, polyVertices
+       , polygon, polyTrail
        , PolygonOpts(..), PolyType(..), PolyOrientation(..)
 
          -- ** Star polygons
@@ -192,19 +194,19 @@ module Diagrams.TwoD
 
        ) where
 
-import Diagrams.TwoD.Types
-import Diagrams.TwoD.Path
-import Diagrams.TwoD.Ellipse
-import Diagrams.TwoD.Arc
-import Diagrams.TwoD.Polygons
-import Diagrams.TwoD.Shapes
-import Diagrams.TwoD.Transform
-import Diagrams.TwoD.Align
-import Diagrams.TwoD.Combinators
-import Diagrams.TwoD.Vector
-import Diagrams.TwoD.Size
-import Diagrams.TwoD.Model
-import Diagrams.TwoD.Text
-import Diagrams.TwoD.Image
+import           Diagrams.TwoD.Align
+import           Diagrams.TwoD.Arc
+import           Diagrams.TwoD.Combinators
+import           Diagrams.TwoD.Ellipse
+import           Diagrams.TwoD.Image
+import           Diagrams.TwoD.Model
+import           Diagrams.TwoD.Path
+import           Diagrams.TwoD.Polygons
+import           Diagrams.TwoD.Shapes
+import           Diagrams.TwoD.Size
+import           Diagrams.TwoD.Text
+import           Diagrams.TwoD.Transform
+import           Diagrams.TwoD.Types
+import           Diagrams.TwoD.Vector
 
-import Diagrams.Util (tau)
+import           Diagrams.Util             (tau)

--- a/src/Diagrams/TwoD/Combinators.hs
+++ b/src/Diagrams/TwoD/Combinators.hs
@@ -51,6 +51,7 @@ import           Diagrams.Combinators
 import           Diagrams.Coordinates
 import           Diagrams.Path
 import           Diagrams.Segment
+import           Diagrams.TrailLike
 import           Diagrams.TwoD.Align
 import           Diagrams.TwoD.Path      ()
 import           Diagrams.TwoD.Segment
@@ -232,10 +233,10 @@ view p (coords -> w :& h) = withEnvelope (rect w h # alignBL # moveTo p :: D R2)
 
 -- | Construct a bounding rectangle for an enveloped object, that is,
 --   the smallest axis-aligned rectangle which encloses the object.
-boundingRect :: ( Enveloped p, Transformable p, PathLike p, V p ~ R2
+boundingRect :: ( Enveloped t, Transformable t, TrailLike t, Monoid t, V t ~ R2
                 , Enveloped a, V a ~ R2
                 )
-             => a -> p
+             => a -> t
 boundingRect = (`boxFit` rect 1 1) . boundingBox
 
 -- | \"Set the background color\" of a diagram.  That is, place a

--- a/src/Diagrams/TwoD/Ellipse.hs
+++ b/src/Diagrams/TwoD/Ellipse.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE FlexibleContexts
-           , TypeSynonymInstances
-           , MultiParamTypeClasses
-           , TypeFamilies
-  #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Ellipse
@@ -23,28 +22,29 @@ module Diagrams.TwoD.Ellipse
     , ellipseXY
     ) where
 
-import Diagrams.Core
+import           Diagrams.Core
 
-import Diagrams.TwoD.Types
-import Diagrams.TwoD.Transform
-import Diagrams.TwoD.Arc
-
-import Diagrams.Path
-import Diagrams.Util
+import           Diagrams.Located        (at)
+import           Diagrams.Path
+import           Diagrams.TrailLike
+import           Diagrams.TwoD.Arc
+import           Diagrams.TwoD.Transform
+import           Diagrams.TwoD.Types
+import           Diagrams.Util
 
 -- | A circle of radius 1, with center at the origin.
-unitCircle :: (PathLike p, V p ~ R2) => p
-unitCircle = pathLike (p2 (1,0)) True $ trailSegments (arcT 0 (tau::Rad))
+unitCircle :: (TrailLike t, V t ~ R2) => t
+unitCircle = trailLike $ arcT 0 (tau::Rad) `at` (p2 (1,0))
 
 -- | A circle of the given radius, centered at the origin.  As a path,
 --   it begins at (r,0).
-circle :: (PathLike p, V p ~ R2, Transformable p) => Double -> p
+circle :: (TrailLike t, V t ~ R2, Transformable t) => Double -> t
 circle d = unitCircle # scale d
 
 -- | @ellipse e@ constructs an ellipse with eccentricity @e@ by
 --   scaling the unit circle in the X direction.  The eccentricity must
 --   be within the interval [0,1).
-ellipse :: (PathLike p, V p ~ R2, Transformable p) => Double -> p
+ellipse :: (TrailLike t, V t ~ R2, Transformable t) => Double -> t
 ellipse e
     | e >= 0 && e < 1  = scaleX (sqrt (1 - e*e)) unitCircle
     | otherwise        = error "Eccentricity of ellipse must be >= 0 and < 1."
@@ -52,5 +52,5 @@ ellipse e
 -- | @ellipseXY x y@ creates an axis-aligned ellipse, centered at the
 --   origin, with radius @x@ along the x-axis and radius @y@ along the
 --   y-axis.
-ellipseXY :: (PathLike p, V p ~ R2, Transformable p) => Double -> Double -> p
+ellipseXY :: (TrailLike t, V t ~ R2, Transformable t) => Double -> Double -> t
 ellipseXY x y = unitCircle # scaleX x # scaleY y

--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Offset
@@ -20,6 +21,7 @@ import Diagrams.Core
 
 import Diagrams.Path
 import Diagrams.Segment
+import Diagrams.Trail
 import Diagrams.TwoD.Curvature
 import Diagrams.TwoD.Transform
 import Diagrams.TwoD.Types
@@ -30,9 +32,9 @@ perp v = rotateBy (-1/4) v
 unitPerp :: R2 -> R2
 unitPerp = normalized . perp
 
-perpAtParam :: Segment R2 -> Double -> R2
-perpAtParam   (Linear a)    t = unitPerp a 
-perpAtParam s@(Cubic _ _ _) t = unitPerp a
+perpAtParam :: Segment Closed R2 -> Double -> R2
+perpAtParam   (Linear (OffsetClosed a))  t = unitPerp a 
+perpAtParam s@(Cubic _ _ _)              t = unitPerp a
   where
     (Cubic a _ _) = snd $ splitAtParam s t
 
@@ -69,14 +71,14 @@ offsetSegment :: Double     -- ^ Epsilon value that represents the maximum
               -> Double     -- ^ Offset from the original segment, positive is
                             --   on the right of the curve, negative is on the
                             --   left.
-              -> Segment R2 -- ^ Original segment
+              -> Segment Closed R2 -- ^ Original segment
               -> (Point R2, Trail R2) -- ^ Resulting offset point and trail.
-offsetSegment _       r s@(Linear a)    = (origin .+^ va, Trail [s] False)
+offsetSegment _       r s@(Linear (OffsetClosed a))    = (origin .+^ va, trailFromSegments [s])
   where va = r *^ unitPerp a
 
-offsetSegment epsilon r s@(Cubic a b c) = (origin .+^ va, t)
+offsetSegment epsilon r s@(Cubic a b (OffsetClosed c)) = (origin .+^ va, t)
   where
-    t = Trail (go (radiusOfCurvature s 0.5)) False
+    t = trailFromSegments (go (radiusOfCurvature s 0.5))
     -- Perpendiculars to handles.
     va = r *^ unitPerp a
     vc = r *^ unitPerp (c - b)
@@ -85,7 +87,7 @@ offsetSegment epsilon r s@(Cubic a b c) = (origin .+^ va, t)
     subdivided = concatMap (trailSegments . snd . offsetSegment epsilon r) ss
 
     -- Offset with handles scaled based on curvature.
-    offset factor = Cubic (a^*factor) ((b - c)^*factor + c + vc - va) (c + vc - va)
+    offset factor = bezier3 (a^*factor) ((b - c)^*factor + c + vc - va) (c + vc - va)
  
     -- We observe a corner.  Subdivide right away.
     go (Finite 0) = subdivided

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -49,12 +49,14 @@ import           Data.AffineSpace
 import           Data.Default.Class
 import           Data.VectorSpace
 
-import           Diagrams.Core
-
 import           Diagrams.Coordinates
+import           Diagrams.Core
+import           Diagrams.Located      (Located, unLoc)
 import           Diagrams.Path
 import           Diagrams.Segment
 import           Diagrams.Solve
+import           Diagrams.Trail
+import           Diagrams.TrailLike
 import           Diagrams.TwoD.Segment
 import           Diagrams.TwoD.Types
 import           Diagrams.Util         (tau)
@@ -68,15 +70,14 @@ import           Diagrams.Util         (tau)
 -- XXX can the efficiency of this be improved?  See the comment in
 -- Diagrams.Path on the Enveloped instance for Trail.
 instance Traced (Trail R2) where
-  getTrace t = case addClosingSegment t of
-    (Trail segs _) ->
-      foldr (\seg bds -> moveOriginBy (negateV . segOffset $ seg) bds <> getTrace seg)
-            mempty
-            segs
+  getTrace = withLine $
+      foldr
+        (\seg bds -> moveOriginBy (negateV . segOffset $ seg) bds <> getTrace seg)
+        mempty
+    . lineSegments
 
 instance Traced (Path R2) where
-  getTrace = F.foldMap trailTrace . pathTrails
-    where trailTrace (p, t) = moveOriginTo ((-1) *. p) (getTrace t)
+  getTrace = F.foldMap getTrace . pathTrails
 
 ------------------------------------------------------------
 --  Constructing path-based diagrams  ----------------------
@@ -96,8 +97,8 @@ stroke :: Renderable (Path R2) b
        => Path R2 -> Diagram b R2
 stroke = stroke' (def :: StrokeOpts ())
 
-instance Renderable (Path R2) b => PathLike (QDiagram b R2 Any) where
-  pathLike st cl segs = stroke $ pathLike st cl segs
+instance Renderable (Path R2) b => TrailLike (QDiagram b R2 Any) where
+  trailLike = stroke . trailLike
 
 -- | A variant of 'stroke' that takes an extra record of options to
 --   customize its behavior.  In particular:
@@ -233,13 +234,13 @@ crossings p = F.sum . map (trailCrossings p) . pathTrails
 
 -- | Compute the sum of signed crossings of a trail starting from the
 --   given point in the positive x direction.
-trailCrossings :: P2 -> (P2, Trail R2) -> Int
+trailCrossings :: P2 -> Located (Trail R2) -> Int
 
-  -- open trails have no inside or outside, so don't contribute crossings
-trailCrossings _ (_, t) | not (isClosed t) = 0
+  -- non-loop trails have no inside or outside, so don't contribute crossings
+trailCrossings _ t | not (isLoop (unLoc t)) = 0
 
-trailCrossings p@(unp2 -> (x,y)) (start, tr)
-  = sum . map test $ fixTrail start tr
+trailCrossings p@(unp2 -> (x,y)) tr
+  = sum . map test $ fixTrail tr
   where
     test (FLinear a@(unp2 -> (_,ay)) b@(unp2 -> (_,by)))
       | ay <= y && by > y && isLeft a b > 0 =  1

--- a/src/Diagrams/TwoD/Segment.hs
+++ b/src/Diagrams/TwoD/Segment.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE FlexibleContexts
-           , FlexibleInstances
-           , UndecidableInstances
-  #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -17,24 +16,25 @@
 
 module Diagrams.TwoD.Segment where
 
-import Control.Applicative (liftA2)
+import           Control.Applicative     (liftA2)
 
-import Data.AffineSpace
-import Data.Monoid.PosInf hiding (minimum)
-import Data.VectorSpace
+import           Data.AffineSpace
+import           Data.Monoid.PosInf      hiding (minimum)
+import           Data.VectorSpace
 
-import Diagrams.Core
-import Diagrams.Core.Trace
+import           Diagrams.Core
+import           Diagrams.Core.Trace
 
-import Diagrams.Segment
-import Diagrams.Solve
-import Diagrams.TwoD.Transform
-import Diagrams.TwoD.Types
-import Diagrams.TwoD.Vector
-import Diagrams.Util
+import           Diagrams.Located
+import           Diagrams.Segment
+import           Diagrams.Solve
+import           Diagrams.TwoD.Transform
+import           Diagrams.TwoD.Types
+import           Diagrams.TwoD.Vector
+import           Diagrams.Util
 
-instance Traced (Segment R2) where
-  getTrace = getTrace . mkFixedSeg origin
+instance Traced (Segment Closed R2) where
+  getTrace = getTrace . mkFixedSeg . (`at` origin)
 
 instance Traced (FixedSegment R2) where
 

--- a/src/Diagrams/TwoD/Shapes.hs
+++ b/src/Diagrams/TwoD/Shapes.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE TypeFamilies
-           , FlexibleContexts
-           , ViewPatterns
-  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -45,62 +43,62 @@ module Diagrams.TwoD.Shapes
        , roundedRect'
        ) where
 
-import Diagrams.Core
+import           Diagrams.Core
 
-import Diagrams.Coordinates
-import Diagrams.Path
-import Diagrams.Segment
-import Diagrams.TwoD.Arc
-import Diagrams.TwoD.Polygons
-import Diagrams.TwoD.Transform
-import Diagrams.TwoD.Types
+import           Diagrams.Coordinates
+import           Diagrams.Located        (at)
+import           Diagrams.Path
+import           Diagrams.Segment
+import           Diagrams.Trail
+import           Diagrams.TrailLike
+import           Diagrams.TwoD.Arc
+import           Diagrams.TwoD.Polygons
+import           Diagrams.TwoD.Transform
+import           Diagrams.TwoD.Types
 
-import Diagrams.Util
+import           Diagrams.Util
 
-import Data.Default.Class
-import Data.Semigroup
+import           Data.Default.Class
+import           Data.Semigroup
 
 -- | Create a centered horizontal (L-R) line of the given length.
-hrule :: (PathLike p, V p ~ R2) => Double -> p
-hrule d = pathLike (p2 (-d/2,0)) False [Linear (d & 0)]
+hrule :: (TrailLike t, V t ~ R2) => Double -> t
+hrule d = trailLike $ trailFromSegments [straight (d & 0)] `at` (p2 (-d/2,0))
 
 -- | Create a centered vertical (T-B) line of the given length.
-vrule :: (PathLike p, V p ~ R2) => Double -> p
-vrule d = pathLike (p2 (0,d/2)) False [Linear (0 & (-d))]
+vrule :: (TrailLike t, V t ~ R2) => Double -> t
+vrule d = trailLike $ trailFromSegments [straight (0 & (-d))] `at` (p2 (0,d/2))
 
 -- | A square with its center at the origin and sides of length 1,
 --   oriented parallel to the axes.
-unitSquare :: (PathLike p, V p ~ R2) => p
+unitSquare :: (TrailLike t, V t ~ R2) => t
 unitSquare = polygon with { polyType   = PolyRegular 4 (sqrt 2 / 2)
                           , polyOrient = OrientH }
 
 -- | A square with its center at the origin and sides of the given
 --   length, oriented parallel to the axes.
-square :: (PathLike p, Transformable p, V p ~ R2) => Double -> p
+square :: (TrailLike t, Transformable t, V t ~ R2) => Double -> t
 square d = rect d d
 
 -- | @rect w h@ is an axis-aligned rectangle of width @w@ and height
 --   @h@, centered at the origin.
-rect :: (PathLike p, Transformable p, V p ~ R2) => Double -> Double -> p
-rect w h = pathLike p True (trailSegments t)
-  where
-    r     = unitSquare # scaleX w # scaleY h
-    (p,t) = head . pathTrails $ r
+rect :: (TrailLike t, Transformable t, V t ~ R2) => Double -> Double -> t
+rect w h = trailLike . head . pathTrails $ unitSquare # scaleX w # scaleY h
 
     -- The above may seem a bit roundabout.  In fact, we used to have
     --
     --   rect w h = unitSquare # scaleX w # scaleY h
     --
-    -- since unitSquare can produce any PathLike.  The current code
+    -- since unitSquare can produce any TrailLike.  The current code
     -- instead uses (unitSquare # scaleX w # scaleY h) to specifically
-    -- produce a Path, which is then deconstructed and passed into
-    -- 'pathLike' to create any PathLike.
+    -- produce a Path, which is then deconstructed and passed back into
+    -- 'trailLike' to create any TrailLike.
     --
     -- The difference is that while scaling by zero works fine for
     -- Path it does not work very well for, say, Diagrams (leading to
     -- NaNs or worse).  This way, we force the scaling to happen on a
     -- Path, where we know it will behave properly, and then use the
-    -- resulting geometry to construct an arbitrary PathLike.
+    -- resulting geometry to construct an arbitrary TrailLike.
     --
     -- See https://github.com/diagrams/diagrams-lib/issues/43 .
 
@@ -114,7 +112,7 @@ rect w h = pathLike p True (trailSegments t)
 --   polygons of a given /radius/).
 --
 --   The polygon will be oriented with one edge parallel to the x-axis.
-regPoly :: (PathLike p, V p ~ R2) => Int -> Double -> p
+regPoly :: (TrailLike t, V t ~ R2) => Int -> Double -> t
 regPoly n l = polygon with { polyType =
                                PolySides
                                  (repeat (1/ fromIntegral n :: CircleFrac))
@@ -123,52 +121,52 @@ regPoly n l = polygon with { polyType =
                            }
 
 -- | A synonym for 'triangle', provided for backwards compatibility.
-eqTriangle :: (PathLike p, V p ~ R2) => Double -> p
+eqTriangle :: (TrailLike t, V t ~ R2) => Double -> t
 eqTriangle = triangle
 
 -- | An equilateral triangle, with sides of the given length and base
 --   parallel to the x-axis.
-triangle :: (PathLike p, V p ~ R2) => Double -> p
+triangle :: (TrailLike t, V t ~ R2) => Double -> t
 triangle = regPoly 3
 
 -- | A regular pentagon, with sides of the given length and base
 --   parallel to the x-axis.
-pentagon :: (PathLike p, V p ~ R2) => Double -> p
+pentagon :: (TrailLike t, V t ~ R2) => Double -> t
 pentagon = regPoly 5
 
 -- | A regular hexagon, with sides of the given length and base
 --   parallel to the x-axis.
-hexagon :: (PathLike p, V p ~ R2) => Double -> p
+hexagon :: (TrailLike t, V t ~ R2) => Double -> t
 hexagon = regPoly 6
 
 -- | A regular septagon, with sides of the given length and base
 --   parallel to the x-axis.
-septagon :: (PathLike p, V p ~ R2) => Double -> p
+septagon :: (TrailLike t, V t ~ R2) => Double -> t
 septagon = regPoly 7
 
 -- | A regular octagon, with sides of the given length and base
 --   parallel to the x-axis.
-octagon :: (PathLike p, V p ~ R2) => Double -> p
+octagon :: (TrailLike t, V t ~ R2) => Double -> t
 octagon = regPoly 8
 
 -- | A regular nonagon, with sides of the given length and base
 --   parallel to the x-axis.
-nonagon :: (PathLike p, V p ~ R2) => Double -> p
+nonagon :: (TrailLike t, V t ~ R2) => Double -> t
 nonagon = regPoly 9
 
 -- | A regular decagon, with sides of the given length and base
 --   parallel to the x-axis.
-decagon :: (PathLike p, V p ~ R2) => Double -> p
+decagon :: (TrailLike t, V t ~ R2) => Double -> t
 decagon = regPoly 10
 
 -- | A regular hendecagon, with sides of the given length and base
 --   parallel to the x-axis.
-hendecagon :: (PathLike p, V p ~ R2) => Double -> p
+hendecagon :: (TrailLike t, V t ~ R2) => Double -> t
 hendecagon = regPoly 11
 
 -- | A regular dodecagon, with sides of the given length and base
 --   parallel to the x-axis.
-dodecagon :: (PathLike p, V p ~ R2) => Double -> p
+dodecagon :: (TrailLike t, V t ~ R2) => Double -> t
 dodecagon = regPoly 12
 
 ------------------------------------------------------------
@@ -185,7 +183,7 @@ dodecagon = regPoly 12
 --   right edge and proceeds counterclockwise.  If you need to specify
 --   a different radius for each corner individually, use
 --   @roundedRect'@ instead.
-roundedRect :: (PathLike p, V p ~ R2) => Double -> Double -> Double -> p
+roundedRect :: (TrailLike t, V t ~ R2) => Double -> Double -> Double -> t
 roundedRect w h r = roundedRect' w h (with { radiusTL = r,
                                              radiusBR = r,
                                              radiusTR = r,
@@ -195,10 +193,12 @@ roundedRect w h r = roundedRect' w h (with { radiusTL = r,
 --   each corner indivually, using @RoundedRectOpts@. The default corner radius is 0.
 --   Each radius can also be negative, which results in the curves being reversed
 --   to be inward instead of outward.
-roundedRect' :: (PathLike p, V p ~ R2) => Double -> Double -> RoundedRectOpts -> p
+roundedRect' :: (TrailLike t, V t ~ R2) => Double -> Double -> RoundedRectOpts -> t
 roundedRect' w h opts
-   = pathLike (p2 (w/2, abs rBR - h/2)) True
-   . trailSegments
+   = trailLike
+   . (`at` (p2 (w/2, abs rBR - h/2)))
+   . wrapTrail
+   . glueLine
    $ seg (0, h - abs rTR - abs rBR)
    <> mkCorner 0 rTR
    <> seg (abs rTR + abs rTL - w, 0)
@@ -207,7 +207,7 @@ roundedRect' w h opts
    <> mkCorner 2 rBL
    <> seg (w - abs rBL - abs rBR, 0)
    <> mkCorner 3 rBR
-  where seg   = fromOffsets . (:[]) . r2
+  where seg   = lineFromOffsets . (:[]) . r2
         diag  = sqrt (w * w + h * h)
         -- to clamp corner radius, need to compare with other corners that share an
         -- edge. If the corners overlap then reduce the largest corner first, as far

--- a/src/Diagrams/TwoD/Vector.hs
+++ b/src/Diagrams/TwoD/Vector.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE FlexibleContexts
-           , TypeFamilies
-           , ViewPatterns
-  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE ViewPatterns     #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Vector
@@ -18,10 +17,15 @@ module Diagrams.TwoD.Vector
 
          -- * Converting between vectors and angles
        , direction, fromDirection,  e
+
+         -- * 2D vector utilities
+       , perp, leftTurn
        ) where
 
-import Diagrams.Coordinates
-import Diagrams.TwoD.Types
+import           Data.VectorSpace     ((<.>))
+import           Diagrams.Coordinates
+import           Diagrams.TwoD.Types
+import           Diagrams.Util        (( # ))
 
 -- | The unit vector in the positive X direction.
 unitX :: R2
@@ -53,3 +57,14 @@ fromDirection a = cos a' & sin a'
 -- | A convenient synonym for 'fromDirection'.
 e :: Angle a => a -> R2
 e = fromDirection
+
+-- | @perp v@ is perpendicular to and has the same magnitude as @v@.
+--   In particular @perp v == rotateBy (1/4) v@.
+perp :: R2 -> R2
+perp (coords -> x :& y) = (-y) & x
+
+-- | @leftTurn v1 v2@ tests whether the direction of @v2@ is a left
+--   turn from @v1@ (that is, if the direction of @v2@ can be obtained
+--   from that of @v1@ by adding an angle 0 <= theta <= tau/2).
+leftTurn :: R2 -> R2 -> Bool
+leftTurn v1 v2 = (v1 <.> perp v2) < 0


### PR DESCRIPTION
- Segments can now be "closed" or "open"
- Trails are "lines" or "loops", represented more correctly and tracked at the type level
- Add a new 'Located' wrapper for adding locations to translation-invariant things
- Change 'PathLike' to 'TrailLike', which now takes a Located Trail

Still more work to do with adding examples to the documentation, etc., but that can be done later.
