### PR TITLE
Make cat' and friends accumulate seperation between empty diagrams

### DIFF
--- a/src/Diagrams/Combinators.hs
+++ b/src/Diagrams/Combinators.hs
@@ -37,13 +37,9 @@ module Diagrams.Combinators
 
        ) where
 
-<<<<<<< HEAD
 import           Data.AdditiveGroup hiding (Sum, getSum)
-=======
 import           Control.Lens       ( (&), (%~), (.~), Lens', makeLensesWith
                                     , lensRules, lensField, generateSignatures, unwrapping)
-import           Data.AdditiveGroup
->>>>>>> master
 import           Data.AffineSpace   ((.+^))
 import           Data.Default.Class
 import           Data.Proxy
@@ -348,7 +344,7 @@ instance Num (Scalar v) => Default (CatOpts v) where
 --
 --   See also 'cat'', which takes an extra options record allowing
 --   certain aspects of the operation to be tweaked.
-cat :: ( Enveloped a, Juxtaposable a, Monoid' a, HasOrigin a
+cat :: ( HasEmpty a, Juxtaposable a, Monoid' a, HasOrigin a
        , InnerSpace (V a), OrderedField (Scalar (V a))
        )
        => V a -> [a] -> a
@@ -371,14 +367,15 @@ cat v = cat' v def
 --   Note that @cat' v with {catMethod = Distrib} === mconcat@
 --   (distributing with a separation of 0 is the same as
 --   superimposing).
-cat' :: ( Enveloped a, Juxtaposable a, Monoid' a, HasOrigin a
+cat' :: ( HasEmpty a, Juxtaposable a, Monoid' a, HasOrigin a
         , InnerSpace (V a), OrderedField (Scalar (V a))
         )
      => V a -> CatOpts (V a) -> [a] -> a
-cat' v (CatOpts { _catMethod = Cat, _sep = s }) = snd . foldB comb mempty . map setSpace
-  where setSpace a = case getOption . unEnvelope . getEnvelope $ a of
-            Nothing -> (Uncut (Sum s), a)
-            Just _  -> (Sum 0 :||: Sum s, a)
+cat' v (CatOpts { _catMethod = Cat, _sep = s })
+    = snd . foldB comb mempty . map setSpace
+  where setSpace a = if isEmpty a
+                     then (Uncut (Sum s), a)
+                     else (Sum 0 :||: Sum s, a)
         unit = normalized (negateV v)
         comb (s1,d1) (s2,d2) = (s1 <> s2, d1 <> juxtapose v d1 d2 # moveOriginBy vs) where
           vs = spacing *^ unit

--- a/src/Diagrams/TwoD/Combinators.hs
+++ b/src/Diagrams/TwoD/Combinators.hs
@@ -109,14 +109,14 @@ atAngle th = beside (fromDirection th)
 --     "Diagrams.TwoD.Align" before applying 'hcat'.
 --
 --   * For non-axis-aligned layout, see 'cat'.
-hcat :: (Enveloped a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
+hcat :: (HasEmpty a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
      => [a] -> a
 hcat = hcat' def
 
 -- | A variant of 'hcat' taking an extra 'CatOpts' record to control
 --   the spacing.  See the 'cat'' documentation for a description of
 --   the possibilities.
-hcat' :: (Enveloped a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
+hcat' :: (HasEmpty a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
       => CatOpts R2 -> [a] -> a
 hcat' = cat' unitX
 
@@ -131,14 +131,14 @@ hcat' = cat' unitX
 --     "Diagrams.TwoD.Align" before applying 'vcat'.
 --
 --   * For non-axis-aligned layout, see 'cat'.
-vcat :: (Enveloped a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
+vcat :: (HasEmpty a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
      => [a] -> a
 vcat = vcat' def
 
 -- | A variant of 'vcat' taking an extra 'CatOpts' record to control
 --   the spacing.  See the 'cat'' documentation for a description of the
 --   possibilities.
-vcat' :: (Enveloped a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
+vcat' :: (HasEmpty a, Juxtaposable a, HasOrigin a, Monoid' a, V a ~ R2)
       => CatOpts R2 -> [a] -> a
 vcat' = cat' (negateV unitY)
 


### PR DESCRIPTION
closes #37 

@byorgey, is this how you want to handle #37?

The test code:

``` haskell
import Diagrams.Prelude
import Diagrams.Backend.SVG

a = let d = hcat' with { sep = 0.2 } [circle 1, mempty, mempty, mempty, circle 1]
        in
     d <> square 1

b = let d = mempty ||| circle 1 in
    d <> square 1

c = let d = hcat' with { sep = 0.2 } [circle 1, circle 1]
        in
     d <> square 1


main :: IO ()
main = renderSVG "bug37.svg" (Dims 400 400) $ (a === b === c) # pad 1.02
```

produces the following output, as expected:

![bug37](https://f.cloud.github.com/assets/251106/1355024/be0ff74c-375e-11e3-86cb-6f403af62ff5.png)
