### PR TITLE
Split fills

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -31,6 +31,7 @@ Library
                        Diagrams.Combinators,
                        Diagrams.Coordinates,
                        Diagrams.Attributes,
+                       Diagrams.Attributes.Compile,
                        Diagrams.Points,
                        Diagrams.Located,
                        Diagrams.Parametric,

--- a/src/Diagrams/Attributes.hs
+++ b/src/Diagrams/Attributes.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE ExistentialQuantification  #-}
-{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Attributes
@@ -62,25 +62,27 @@ module Diagrams.Attributes (
 
   ) where
 
-import           Control.Arrow         (second)
-import           Control.Lens          (Setter, sets, (%~), (&), _Wrapping')
+import           Control.Arrow               (second)
+import           Control.Lens                (Setter, sets, (%~), (&),
+                                              _Wrapping')
 import           Data.Colour
-import           Data.Colour.RGBSpace  (RGB (..))
-import           Data.Colour.SRGB      (toSRGB)
+import           Data.Colour.RGBSpace        (RGB (..))
+import           Data.Colour.SRGB            (toSRGB)
 import           Data.Default.Class
-import qualified Data.Map              as M
-import           Data.Maybe            (fromMaybe)
+import qualified Data.Map                    as M
+import           Data.Maybe                  (fromMaybe)
 import           Data.Monoid.Recommend
 import           Data.Semigroup
 import           Data.Tree
 import           Data.Typeable
 
+import           Diagrams.Attributes.Compile
 import           Diagrams.Core
-import           Diagrams.Core.Style   (Style (..), attrToStyle, setAttr)
-import           Diagrams.Core.Types   (RNode (..), RTree)
-import           Diagrams.Located      (unLoc)
-import           Diagrams.Path         (Path, pathTrails)
-import           Diagrams.Trail        (isLine)
+import           Diagrams.Core.Style         (Style (..), attrToStyle, setAttr)
+import           Diagrams.Core.Types         (RNode (..), RTree)
+import           Diagrams.Located            (unLoc)
+import           Diagrams.Path               (Path, pathTrails)
+import           Diagrams.Trail              (isLoop)
 
 ------------------------------------------------------------
 --  Color  -------------------------------------------------
@@ -405,88 +407,19 @@ dashing ds offs = applyAttr (DashingA (Last (Dashing ds offs)))
 
 ------------------------------------------------------------
 
--- | Push fill attributes down until they are at the roots of trees
---   containing only loops.  This makes life much easier for backends,
+data FillLoops v = FillLoops
+
+instance Typeable v => SplitAttribute (FillLoops v) where
+  type AttrType (FillLoops v) = FillColor
+  type PrimType (FillLoops v) = Path v
+
+  primOK _ = all (isLoop . unLoc) . pathTrails
+
+-- | Push fill attributes down until they are at the root of subtrees
+--   containing only loops. This makes life much easier for backends,
 --   which typically have a semantics where fill attributes are
 --   applied to lines/non-closed paths as well as loops/closed paths,
 --   whereas in the semantics of diagrams, fill attributes only apply
 --   to loops.
 splitFills :: forall b v a. Typeable v => RTree b v a -> RTree b v a
-splitFills = fst . splitFills' Nothing
-  where
-
-  -- splitFills' is where the most interesting logic happens.
-  -- Mutually recursive with splitFills'Forest. rebuildNode and
-  -- applyMfc are helper functions.
-  --
-  -- Input: fill attribute to apply to subtrees containing only loops.
-  --
-  -- Output: tree with fill attributes pushed down appropriately, and
-  -- a Bool indicating whether the tree contains only loops (True) or
-  -- contains some lines (False).
-  splitFills' :: Maybe FillColor -> RTree b v a -> (RTree b v a, Bool)
-
-  -- RStyle node: Check for a fill attribute, and split it out of the
-  -- style, combining it with the incoming fill attribute.  Recurse
-  -- and rebuild.
-  splitFills' mfc (Node (RStyle sty) cs) = (t', ok)
-    where
-      mfc' = mfc <> getAttr sty
-      sty' = sty & _Wrapping' Style %~ M.delete ty
-      ty   = show . typeOf $ (undefined :: FillColor)
-      (cs', ok) = splitFills'Forest mfc' cs
-      t' | ok        = rebuildNode Nothing ok (RStyle sty) cs'
-         | otherwise = rebuildNode mfc ok (RStyle sty') cs'
-
-  -- RPrim node: check whether it
-  --   * is not a path : don't apply the fill; return True
-  --   * contains lines: don't apply the fill; return False
-  --   * contains loops:  do   apply the fill; return True
-  splitFills' mfc (Node rp@(RPrim _ (Prim p)) _) =
-      case cast p :: Maybe (Path v) of
-        Nothing  -> (Node rp [], True)
-        Just pth ->
-          case any (isLine . unLoc) . pathTrails $ pth of
-            True  -> (Node rp [], False)
-            False -> (rebuildNode mfc True rp [], True)
-
-  -- RFrozenTr, RAnnot, REmpty cases: just recurse and rebuild.  Note
-  -- that transformations do not affect fill attributes.
-  splitFills' mfc (Node nd cs)    = (t', ok)
-    where
-      (cs', ok) = splitFills'Forest mfc cs
-      t'        = rebuildNode mfc ok nd cs'
-
-  -- Recursively call splitFills' on all subtrees, returning the
-  -- logical AND of the Bool results returned (the whole forest
-  -- contains only loops iff all the subtrees do).  The tricky bit is
-  -- that we use some knot-tying to determine the right attribute to pass
-  -- down to the subtrees based on this computed Bool: if all subtrees
-  -- contain only loops, then we will apply the fill at the root of
-  -- this forest, and pass Nothing to all the subtrees.  Otherwise, we
-  -- pass the given fill along.  This works out because the fill
-  -- does not need to be pattern-matched until actually applying it at
-  -- some root, so the recursion can proceed and the Bool values be
-  -- computed with the actual value of the fill nodes filled in
-  -- lazily.
-  splitFills'Forest :: Maybe FillColor -> [RTree b v a] -> ([RTree b v a], Bool)
-  splitFills'Forest mfc cs = (cs', ok)
-    where
-      (cs', ok) = second and . unzip . map (splitFills' mfc') $ cs
-      mfc' | ok        = Nothing
-           | otherwise = mfc
-
-  -- Given a fill attribute, a Bool indicating whether the given
-  -- subforest contains only loops, a node, and a subforest, rebuild a
-  -- tree, applying the fill attribute as appropriate (only if the
-  -- Bool is true and the attribute is not Nothing).
-  rebuildNode :: Maybe FillColor -> Bool -> RNode b v a -> [RTree b v a] -> RTree b v a
-  rebuildNode mfc ok nd cs
-    | ok        = applyMfc mfc (Node nd cs)
-    | otherwise = Node nd cs
-
-  -- Prepend a new fill color node if Just; the identity function if
-  -- Nothing.
-  applyMfc :: Maybe FillColor -> RTree b v a -> RTree b v a
-  applyMfc Nothing  t = t
-  applyMfc (Just f) t = Node (RStyle $ attrToStyle f) [t]
+splitFills = splitAttr (FillLoops :: FillLoops v)

--- a/src/Diagrams/Attributes/Compile.hs
+++ b/src/Diagrams/Attributes/Compile.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams.Attributes.Compile
+-- Copyright   :  (c) 2014 diagrams-lib team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- XXX
+--
+-----------------------------------------------------------------------------
+
+module Diagrams.Attributes.Compile (
+    SplitAttribute(..), splitAttr
+  ) where
+
+import           Data.Typeable
+
+import           Control.Arrow       (second)
+import           Control.Lens        ((%~), (&), _Wrapping')
+import qualified Data.Map            as M
+import           Data.Semigroup      ((<>))
+import           Data.Tree           (Tree (..))
+
+import           Diagrams.Core
+import           Diagrams.Core.Style (Style (..), attrToStyle)
+import           Diagrams.Core.Types (RNode (..), RTree)
+
+------------------------------------------------------------
+
+-- This is a sort of roundabout, overly-general way to define
+-- splitFills; it's done this way to facilitate testing.
+
+class (AttributeClass (AttrType code), Typeable (PrimType code)) => SplitAttribute code where
+  type AttrType code :: *
+  type PrimType code :: *
+
+  primOK :: code -> PrimType code -> Bool
+
+-- | Push certain attributes down until they are at the roots of trees
+--   containing only "safe" nodes.  In particular this is used to push
+--   fill attributes down until they are over only loops; see
+--   'splitFills'.
+splitAttr :: forall code b v a. SplitAttribute code => code -> RTree b v a -> RTree b v a
+splitAttr code = fst . splitAttr' Nothing
+  where
+
+  -- splitAttr' is where the most interesting logic happens.
+  -- Mutually recursive with splitAttr'Forest. rebuildNode and
+  -- applyMfc are helper functions.
+  --
+  -- Input: attribute to apply to "safe" subtrees.
+  --
+  -- Output: tree with attributes pushed down appropriately, and
+  -- a Bool indicating whether the tree contains only "safe" prims (True) or
+  -- contains some unsafe ones (False).
+  splitAttr' :: Maybe (AttrType code) -> RTree b v a -> (RTree b v a, Bool)
+
+  -- RStyle node: Check for the special attribute, and split it out of
+  -- the style, combining it with the incoming attribute.  Recurse and
+  -- rebuild. The tricky bit is that we use some knot-tying to
+  -- determine the right attribute to pass down to the subtrees based
+  -- on this computed Bool: if all subtrees are safe, then we will
+  -- apply the attribute at the root of this tree, and pass Nothing to
+  -- all the subtrees.  Otherwise, we pass the given attribute along.
+  -- This works out because the attribute does not need to be
+  -- pattern-matched until actually applying it at some root, so the
+  -- recursion can proceed and the Bool values be computed with the
+  -- actual value of the attributes nodes filled in lazily.
+  splitAttr' mattr (Node (RStyle sty) cs) = (t', ok)
+    where
+      mattr' = mattr <> getAttr sty
+      sty' = sty & _Wrapping' Style %~ M.delete ty
+      ty   = show . typeOf $ (undefined :: AttrType code)
+      (cs', ok) = splitAttr'Forest mattr' cs
+      t' | ok        = rebuildNode Nothing ok (RStyle sty) cs'
+         | otherwise = rebuildNode mattr ok (RStyle sty') cs'
+
+  -- RPrim node: check whether it
+  --   * is some sort of prim not under consideration: don't apply the attribute; return True
+  --   * is unsafe: don't apply the attribute; return False
+  --   * is safe  :  do   apply the attribute; return True
+  splitAttr' mattr (Node rp@(RPrim _ (Prim prm)) _) =
+      case cast prm :: Maybe (PrimType code) of
+        Nothing  -> (Node rp [], True)
+        Just p ->
+          case primOK code p of
+            True  -> (rebuildNode mattr True rp [], True)
+            False -> (Node rp [], False)
+
+  -- RFrozenTr, RAnnot, REmpty cases: just recurse and rebuild.  Note
+  -- we assume that transformations do not affect the attributes.
+  splitAttr' mattr (Node nd cs)    = (t', ok)
+    where
+      (cs', ok) = splitAttr'Forest mattr cs
+      t'        = rebuildNode mattr ok nd cs'
+
+  -- Recursively call splitAttr' on all subtrees, returning the
+  -- logical AND of the Bool results returned (the whole forest is
+  -- safe iff all subtrees are).
+  splitAttr'Forest :: Maybe (AttrType code) -> [RTree b v a] -> ([RTree b v a], Bool)
+  splitAttr'Forest mattr cs = (cs', ok)
+    where
+      (cs', ok) = second and . unzip . map (splitAttr' mattr) $ cs
+
+  -- Given a fill attribute, a Bool indicating whether the given
+  -- subforest contains only loops, a node, and a subforest, rebuild a
+  -- tree, applying the fill attribute as appropriate (only if the
+  -- Bool is true and the attribute is not Nothing).
+  rebuildNode :: Maybe (AttrType code) -> Bool -> RNode b v a -> [RTree b v a] -> RTree b v a
+  rebuildNode mattr ok nd cs
+    | ok        = applyMattr mattr (Node nd cs)
+    | otherwise = Node nd cs
+
+  -- Prepend a new fill color node if Just; the identity function if
+  -- Nothing.
+  applyMattr :: Maybe (AttrType code) -> RTree b v a -> RTree b v a
+  applyMattr Nothing  t = t
+  applyMattr (Just a) t = Node (RStyle $ attrToStyle a) [t]

--- a/test/SplitAttr.hs
+++ b/test/SplitAttr.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+import           Control.Applicative
+import           Control.Lens                ((%~), (&), _Wrapping')
+import           Control.Monad
+import qualified Data.Map                    as M
+import           Data.Semigroup
+import           Data.Tree
+import           Data.Typeable
+import           Diagrams.Attributes.Compile
+import           Diagrams.Core
+import           Diagrams.Core.Style
+import           Diagrams.Core.Types
+import           Diagrams.Prelude            (R2)
+import           Test.QuickCheck
+
+data FakePath = Ln | Lp
+  deriving (Show, Eq, Typeable)
+
+type instance V FakePath = R2
+
+instance Transformable FakePath where
+  transform _ = id
+
+instance Renderable FakePath NullBackend where
+  render _ _ = undefined
+
+instance IsPrim FakePath where
+
+data A = A
+  deriving (Typeable, Show, Eq, Ord)
+instance Semigroup A where
+  A <> A = A
+instance AttributeClass A
+
+data B = B
+  deriving (Typeable, Show, Eq, Ord)
+instance Semigroup B where
+  B <> B = B
+instance AttributeClass B
+
+data FillLoopsTest = FillLoopsTest
+
+instance SplitAttribute FillLoopsTest where
+  type AttrType FillLoopsTest = A
+  type PrimType FillLoopsTest = FakePath
+
+  primOK _ l = l == Lp
+
+showRTree :: RTree b v a -> String
+showRTree = drawTree . fmap show
+
+instance Show (RNode b v a) where
+  show (RStyle s) = "<" ++ showAttr A s ++ showAttr B s ++ ">"
+  show (RPrim _ (Prim p)) =
+    case cast p of
+      Nothing               -> "<P>"
+      Just (fp :: FakePath) -> "\"" ++ show fp ++ "\""
+  show _ = "."
+
+showAttr :: forall a v. (Show a, AttributeClass a) => a -> Style v -> String
+showAttr _ s = maybe "" show (getAttr s :: Maybe a)
+
+instance Eq (RNode b v a) where
+  r1 == r2 = show r1 == show r2
+
+instance Arbitrary (RNode b v a) where
+  arbitrary = oneof [pure REmpty, s $ attrToStyle A, s $ attrToStyle B, s $ attrToStyle A <> attrToStyle B]
+    where
+      s = pure . RStyle
+  shrink REmpty = []
+  shrink _ = [REmpty]
+
+arbPrim :: Gen (RNode NullBackend R2 ())
+arbPrim = (RPrim mempty . Prim) <$> elements [Ln, Lp]
+
+genTree :: Int -> Gen (Tree (RNode NullBackend R2 ()))
+genTree n | n <= 0 = Node <$> arbitrary <*> pure []
+genTree n = do
+  len <- choose (0,3)
+  if len == 0
+    then Node <$> arbPrim   <*> pure []
+    else Node <$> arbitrary <*> replicateM len (genTree (n - 1))
+
+instance Arbitrary (Tree (RNode NullBackend R2 ())) where
+  arbitrary = sized genTree
+  shrink (Node r ts)
+    =  [ t          | t <- ts          ]
+    ++ [ Node r ts' | ts' <- splices ts ]
+    ++ [ Node r' ts | r'  <- shrink r  ]
+    ++ [ Node r ts' | ts' <- shrink ts ]
+    where
+      splices :: [Tree a] -> [[Tree a]]
+      splices [] = []
+      splices (t@(Node _ cs) : ts) = (cs ++ ts) : (map (t :) (splices ts))
+
+splitA = splitAttr FillLoopsTest
+
+newtype PrettyTree = PT (RTree NullBackend R2 ())
+  deriving (Arbitrary)
+
+instance Show PrettyTree where
+  show (PT t) = showRTree t
+
+------------------------------------------------------------
+-- Properties!
+
+-- should preserve semantics
+-- should result in attributes in question only being over OK nodes
+-- should not move other attributes
+
+{-
+
+-- Should preserve tree shape?
+-- Actually, this isn't true (and shouldn't be)!  New RStyle nodes have
+-- to get introduced sometimes.
+
+class Matchable m where
+  matches :: m -> m -> Bool
+  matches _ _ = True
+
+instance Matchable m => Matchable [m] where
+  matches [] [] = True
+  matches (x:xs) (y:ys) = matches x y && matches xs ys
+  matches _ _ = False
+
+instance Matchable m => Matchable (Tree m) where
+  matches (Node x xs) (Node y ys)
+    = matches x y && matches xs ys
+
+instance Matchable (RNode b v a)
+
+prop_split_pres_shape :: PrettyTree -> Bool
+prop_split_pres_shape (PT t) = matches t (splitA t)
+-}
+
+-- Should preserve semantics
+
+type AB = (Maybe A, Maybe B)
+
+removeA :: AB -> AB
+removeA (_,b) = (Nothing,b)
+
+flattenTree :: Style R2 -> RTree NullBackend R2 () -> [(Style R2, FakePath)]
+flattenTree sty (Node REmpty ts) = flattenForest sty ts
+flattenTree sty (Node (RStyle sty') ts) = flattenForest (sty <> sty') ts
+flattenTree sty (Node (RPrim _ (Prim p)) _) =
+  case cast p of
+    Nothing -> []
+    Just (l :: FakePath) -> [(sty, l)]
+flattenTree sty _ = []
+
+flattenForest :: Style R2 -> [RTree NullBackend R2 ()] -> [(Style R2, FakePath)]
+flattenForest = concatMap . flattenTree
+
+semantics :: RTree NullBackend R2 () -> [(AB, FakePath)]
+semantics = map postProcess . flattenTree mempty
+  where
+    styleToAB :: Style R2 -> AB
+    styleToAB = (,) <$> getAttr <*> getAttr
+    postProcess (sty, l) = ((if l == Ln then removeA else id) (styleToAB sty), l)
+
+prop_splitA_pres_semantics :: PrettyTree -> Bool
+prop_splitA_pres_semantics (PT t) = semantics t == semantics (splitA t)
+
+-- Ha, this one caught a bug! Success! =D


### PR DESCRIPTION
I am not entirely happy with this, since it seems overly complicated, and even I am not quite sure I believe it is really correct.  Still, it does help squish a tricky bug (https://github.com/diagrams/diagrams-svg/issues/43) which is actually a problem for some users (https://github.com/timbod7/haskell-chart/issues/19), and passes the tests I could think of (see `test/SplitAttr.hs`).

See also the discussion at https://github.com/diagrams/diagrams-lib/pull/141 .
