### PR TITLE
fix doc for === and |||

### DIFF
--- a/src/Diagrams/TwoD/Combinators.hs
+++ b/src/Diagrams/TwoD/Combinators.hs
@@ -76,7 +76,7 @@ infixl 6 |||
 --
 --   to place @c@ above @d@.  The local origin of the resulting
 --   combined diagram is the same as the local origin of the first.
---   @(|||)@ is associative and has 'mempty' as an identity.  See the
+--   @(===)@ is associative and has 'mempty' as an identity.  See the
 --   documentation of 'beside' for more information.
 (===) :: (Juxtaposable a, V a ~ R2, Semigroup a) => a -> a -> a
 (===) = beside (negateV unitY)
@@ -84,7 +84,7 @@ infixl 6 |||
 -- | Place two diagrams (or other juxtaposable objects) horizontally
 --   adjacent to one another, with the first diagram to the left of
 --   the second.  The local origin of the resulting combined diagram
---   is the same as the local origin of the first.  @(===)@ is
+--   is the same as the local origin of the first.  @(|||)@ is
 --   associative and has 'mempty' as an identity.  See the
 --   documentation of 'beside' for more information.
 (|||) :: (Juxtaposable a, V a ~ R2, Semigroup a) => a -> a -> a


### PR DESCRIPTION
here is a minuscule contribution to fix the doc-comments for === and |||
