### PR TITLE
updated the upper bounds of the .cabal constraints for 'semigroups' package

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -93,7 +93,7 @@ Library
   Build-depends:       base >= 4.2 && < 4.8,
                        containers >= 0.3 && < 0.6,
                        array >= 0.3 && < 0.6,
-                       semigroups >= 0.3.4 && < 0.13,
+                       semigroups >= 0.3.4 && < 0.14,
                        monoid-extras >= 0.3 && < 0.4,
                        dual-tree >= 0.2 && < 0.3,
                        diagrams-core >= 1.1 && < 1.2,


### PR DESCRIPTION
from: "< 0.13" to "< 0.14"

diagrams-core already has "< 0.14" and the "< 0.13" constraint  causes some packages to break (i.e. conduit)
