### PR TITLE
make headSize and tailSize back into ArrowOpts fields

### DIFF
--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -153,10 +153,8 @@ module Diagrams.TwoD
        , tailStyle
        , shaftColor
        , shaftStyle
-       , HeadSize, headSize, headSizeA, getHeadSize
-       , headSizeO, headSizeL, headSizeN, headSizeG
-       , TailSize, tailSize, tailSizeA, getTailSize
-       , tailSizeO, tailSizeL, tailSizeN, tailSizeG
+       , headSize
+       , tailSize
 
          -- * Text
        , text, topLeftText, alignedText, baselineText

--- a/src/Diagrams/TwoD/Adjust.hs
+++ b/src/Diagrams/TwoD/Adjust.hs
@@ -22,7 +22,6 @@ module Diagrams.TwoD.Adjust
 import           Diagrams.Attributes      (lineCap, lineColorA, lineJoin,
                                            lineMiterLimitA)
 import           Diagrams.Core
-import           Diagrams.TwoD.Arrow      (headSizeA, tailSizeA)
 import           Diagrams.TwoD.Attributes (lineWidthA)
 import           Diagrams.TwoD.Size       (SizeSpec2D (..), center2D,
                                            requiredScale, size2D)
@@ -52,7 +51,6 @@ import           Data.Semigroup
 setDefault2DAttributes :: Semigroup m => QDiagram b R2 m -> QDiagram b R2 m
 setDefault2DAttributes d = d # lineWidthA def # lineColorA def # fontSizeA def
                              # lineCap def # lineJoin def # lineMiterLimitA def
-                             # headSizeA def # tailSizeA def
 
 -- | Adjust the size and position of a 2D diagram to fit within the
 --   requested size. The first argument is a lens into the output


### PR DESCRIPTION
As attributes, there are situations where it is actually impossible (or
at least very difficult) to get things the way you want.  E.g. imagine
creating a whole bunch of arrows via connectOutside and applyAll, but
you want them to have all different head sizes.  I am not sure how to
accomplish this via attributes at the moment.

It is also simply annoying to have some arrow attributes set via
ArrowOpts and some as normal attributes.  I ran into this when updating
the website gallery, it was a confusing error and would have been
annoying to fix.

In the long term, I would love to have all arrow attributes be normal
attributes... but that may have to wait until we have constraint solving
and can declare arrows as separate standalone diagrams (to which
attributes can be applied).

Note this does mean deleting headSizeG, headSizeO, etc. It would be
ideal to be able to write e.g. `... & headSizeG .~ 3 & ...`
rather than `... & headSize (Global 3) & ...`, however, such a
`headSizeG` would not be a valid lens.
