### PR TITLE
Non lenses

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -106,7 +106,7 @@ Library
                        data-default-class < 0.1,
                        fingertree >= 0.1 && < 0.2,
                        intervals >= 0.7 && < 0.8,
-                       lens >= 4.0 && < 4.3,
+                       lens >= 4.0 && < 4.4,
                        tagged >= 0.7,
                        optparse-applicative >= 0.7 && < 0.10,
                        filepath,

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -23,7 +23,7 @@ module Diagrams.Angle
        , HasTheta(..)
        ) where
 
-import Control.Lens            (Iso', Lens', iso, review, (^.))
+import Control.Lens            (Iso', Getter, iso, review, (^.))
 
 import Data.Monoid      hiding ((<>))
 import Data.Semigroup
@@ -123,4 +123,4 @@ angleBetween v1 v2 = acos (normalized v1 <.> normalized v2) @@ rad
 
 -- | The class of types with at least one angle coordinate, called _theta.
 class HasTheta t where
-    _theta :: Lens' t Angle
+    _theta :: Getter t Angle

--- a/src/Diagrams/ThreeD/Shapes.hs
+++ b/src/Diagrams/ThreeD/Shapes.hs
@@ -21,7 +21,7 @@ module Diagrams.ThreeD.Shapes
        ) where
 
 import           Control.Applicative
-import           Control.Lens           (review, (^.), _1)
+import           Control.Lens           ((^.))
 import           Data.Typeable
 
 import           Data.AffineSpace
@@ -129,7 +129,7 @@ frustum r0 r1 = mkQD (Prim $ Frustum r0 r1 mempty)
     frEnv v = maximum . map (magnitude . project v . fromCylindrical) $ corners
       where
         θ = v^._theta
-        fromCylindrical (r,θ,z) = (z *^ unitZ) ^+^ (r *^ (transform (aboutZ θ) unitX))
+        fromCylindrical (r,th,z) = (z *^ unitZ) ^+^ (r *^ (transform (aboutZ th) unitX))
         corners = [(r1,θ,1), (-r1,θ,1), (r0,θ,0), (-r0,θ,0)]
     -- The trace can intersect the sides of the cone or one of the end
     -- caps The sides are described by a quadric equation; substitute
@@ -147,8 +147,8 @@ frustum r0 r1 = mkQD (Prim $ Frustum r0 r1 mempty)
         c = px**2 + py**2 - (r0 + dr*pz)**2
         zbounds t = (ray t)^._z >= 0 && (ray t)^._z <= 1
         ends = concatMap cap [0,1]
-        fromZAxis p = let v = p .-. origin
-                      in magnitude $ v ^-^ project unitZ v
+        fromZAxis q = let u = q .-. origin
+                      in magnitude $ u ^-^ project unitZ u
         cap z = if (fromZAxis $ ray t) < r0 + z*dr
                 then [t]
                 else []

--- a/src/Diagrams/ThreeD/Types.hs
+++ b/src/Diagrams/ThreeD/Types.hs
@@ -26,8 +26,8 @@ module Diagrams.ThreeD.Types
        , r3Iso, p3Iso
        ) where
 
-import           Control.Lens           (Iso', Lens', iso, lens, over, to
-                                        , _1, _2, _3, (^.))
+import           Control.Lens           (Iso', iso, lens, over, to
+                                        , _1, _2, _3)
 
 import           Diagrams.Core
 import           Diagrams.Angle

--- a/src/Diagrams/TwoD/Arc.hs
+++ b/src/Diagrams/TwoD/Arc.hs
@@ -34,7 +34,7 @@ import           Diagrams.TwoD.Types
 import           Diagrams.TwoD.Vector    (unitX, unitY, unit_Y)
 import           Diagrams.Util           (( # ))
 
-import           Control.Lens            ((^.), (&), (<>~))
+import           Control.Lens            ((^.))
 import           Data.AffineSpace
 import           Data.Semigroup          ((<>))
 import           Data.VectorSpace

--- a/src/Diagrams/TwoD/Arc.hs
+++ b/src/Diagrams/TwoD/Arc.hs
@@ -157,7 +157,7 @@ arcBetween p q ht = trailLike (a # rotate (v^._theta) # moveTo p)
     r = d/(2*sinA th)
     mid | ht >= 0    = direction unitY
         | otherwise  = direction unit_Y
-    st  = mid & _theta <>~ (negateV th)
+    st  = rotate (negateV th) mid
     a | isStraight
       = fromOffsets [d *^ unitX]
       | otherwise
@@ -188,4 +188,4 @@ annularWedge r1' r2' d1 s = trailLike . (`at` o) . glueTrail . wrapLine
                 <> fromOffsets [(r1'-r2') *^ negateV (fromDirection d2)]
                 <> arc d2 (negateV s) # scale r2'
   where o = origin # translate (r2' *^ fromDirection d1)
-        d2 = d1 & _theta <>~ s
+        d2 = rotate s d1

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -130,10 +130,10 @@ arrowheadSpike theta len shaftWidth  = (hd # scale r, jt # scale r)
   where
     hd = snugL . closedPath $ l1 <> c <> l2
     jt = alignR . centerY . pathFromTrail
-                . closeTrail $ arc' 1 (xDir & _theta <>~ (negateV phi)) (2 *^ phi)
+                . closeTrail $ arc' 1 (rotate (negateV phi) xDir) (2 *^ phi)
     l1 = trailFromSegments [straight $ unit_X ^+^ v]
     l2 = trailFromSegments [reverseSegment . straight $ (unit_X ^+^ (reflectY v))]
-    c = reflectX $ arc' 1 (xDir & _theta <>~ theta) ((-2) *^ theta)
+    c = reflectX $ arc' 1 (rotate theta xDir) ((-2) *^ theta)
     v = rotate theta unitX
 
     -- The length of the head without its joint is, -2r cos theta and

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -54,7 +54,7 @@ module Diagrams.TwoD.Arrowheads
        , ArrowHT
        ) where
 
-import           Control.Lens            ((&), (.~), (^.), (<>~))
+import           Control.Lens            ((&), (.~), (^.))
 import           Data.AffineSpace
 import           Data.Default.Class
 import           Data.Monoid             (mempty, (<>))

--- a/src/Diagrams/TwoD/Shapes.hs
+++ b/src/Diagrams/TwoD/Shapes.hs
@@ -61,7 +61,7 @@ import           Diagrams.TwoD.Vector
 
 import           Diagrams.Util
 
-import           Control.Lens            (makeLenses, op, (&), (.~), (^.), (<>~))
+import           Control.Lens            (makeLenses, op, (&), (.~), (^.))
 import           Data.Default.Class
 import           Data.Semigroup
 
@@ -315,4 +315,4 @@ roundedRect' w h opts
                      | otherwise = doArc 0 1
                      where
                        doArc d s =
-                           arc' r (xDir & _theta <>~ ((k+d)/4 @@ turn)) (s/4 @@ turn)
+                           arc' r (rotate ((k+d)/4 @@ turn) xDir) (s/4 @@ turn)

--- a/src/Diagrams/TwoD/Types.hs
+++ b/src/Diagrams/TwoD/Types.hs
@@ -27,7 +27,8 @@ module Diagrams.TwoD.Types
 
        ) where
 
-import           Control.Lens           (Iso', Rewrapped, Wrapped (..), iso, (^.),  _1, _2)
+import           Control.Lens           (Iso', Rewrapped, Wrapped (..)
+                                        , iso, lens, to, (^.),  _1, _2)
 
 
 import           Diagrams.Angle
@@ -182,10 +183,10 @@ instance HasY R2 where
     _y = r2Iso . _2
 
 instance HasTheta R2 where
-    _theta = polar._2
+    _theta = to $ \v -> atan2A (v^._y) (v^._x)
 
 instance HasR R2 where
-    _r = polar._1
+    _r = lens magnitude (\v r -> v ^* (r / magnitude v))
 
 instance HasTheta (Direction R2) where
     _theta = _Dir . _theta
@@ -247,15 +248,3 @@ instance HasR P2 where
 
 instance HasTheta P2 where
     _theta = _relative origin . _theta
-
--- | Types which can be expressed in polar 2D coordinates, as a magnitude and an angle.
-class Polar t where
-    polar :: Iso' t (Double, Angle)
-
-instance Polar R2 where
-    polar =
-        iso (\v -> ( magnitude v, atan2A (v^._y) (v^._x)))
-            (\(r,θ) -> R2 (r * cosA θ) (r * sinA θ))
-
-instance Polar P2 where
-    polar = _relative origin . polar

--- a/src/Diagrams/TwoD/Vector.hs
+++ b/src/Diagrams/TwoD/Vector.hs
@@ -56,7 +56,7 @@ xDir = direction unitX
 -- | A unit vector at a specified angle counterclockwise from the
 -- positive X axis.
 e :: Angle -> R2
-e a = unitX & _theta .~ a
+e a = R2 (cosA a) (sinA a)
 
 -- | @perp v@ is perpendicular to and has the same magnitude as @v@.
 --   In particular @perp v == rotateBy (1/4) v@.

--- a/src/Diagrams/TwoD/Vector.hs
+++ b/src/Diagrams/TwoD/Vector.hs
@@ -23,8 +23,6 @@ module Diagrams.TwoD.Vector
        , perp, leftTurn
        ) where
 
-import Control.Lens ((&), (.~))
-
 import Data.VectorSpace
 
 import Diagrams.Angle


### PR DESCRIPTION
We need to remove these non-lenses.  I'm not completely happy with the solution here.  Suggestions?  Some other options include:

* make `_theta` a plain function instead of a Getter (see commit msg for counterpoint)
* drop the `HasTheta` class, but keep a monomorphic `_theta` for the 15-20 uses in this library (due to changed `direction`)
* rename `_theta`