### PR TITLE
add semi-portable looping using fsnotify

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -114,7 +114,7 @@ Library
                        JuicyPixels >= 3.1.5 && < 3.2,
                        hashable >= 1.1 && < 1.3,
                        process >= 1.1 && < 1.3,
-                       fsnotify >= 0.0.11 && < 0.2,
+                       fsnotify >= 0.1 && < 0.2,
                        directory >= 1.2 && < 1.3,
                        system-filepath >= 0.2 && < 0.5,
                        text >= 0.7.1 && < 1.2

--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -584,7 +584,10 @@ defaultLoopRender opts = when (opts ^. loop) $ do
                      -- Call the new program without the looping option
                      (\ev -> print ev >> recompile srcPath newProg  >>= run newProg (filter (/= "-l") args))
             putStrLn "entering infinite loop"
-            forever $ threadDelay maxBound
+            forever . threadDelay $ case os of
+                -- https://ghc.haskell.org/trac/ghc/ticket/7325
+                                     "darwin" -> 1000000000000
+                                     _ -> maxBound
 
 recompile :: FilePath -> FilePath -> IO ExitCode
 recompile srcFile outFile = do


### PR DESCRIPTION
generic defaultLoopRender for use in Backends

See matching branches of `-cairo` and `-rasterific`.

This seems to work well on Linux.  It works some of the time on Windows; other times `fsnotify` seems to not register a change, or the program compiles and runs an older copy of the source file.  Please don't merge until I have spent more time debugging that.

I'd appreciate if someone could test this on a Mac.  The `-rasterific` branch should be fine.  My test program is:

``` haskell
import Diagrams.Prelude
import Diagrams.Backend.Rasterific.CmdLine

dia :: Animation B R2
dia = c <$> ui where
  c t = circle 1 # fc (blend t white green) # pad 1.01

main :: IO ()
main = mainWith dia
```
- compile test program
- run as ./Animation -w 400 --fpu 5 -o animTest.png -l
- edit source file at least twice to trigger recompilation 
  (there were some earlier bugs where it would recompile after the first edit, but not again)
