### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -104,7 +104,7 @@ Library
                        data-default-class < 0.1,
                        fingertree >= 0.1 && < 0.2,
                        intervals >= 0.7 && < 0.8,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.12,
                        filepath,


### PR DESCRIPTION
Allow `diagrams-lib` to use the latest version of `lens` (4.5).
