### PR TITLE
Update diagrams-lib.cabal : bumping JuicyPixels dependency

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -110,7 +110,7 @@ Library
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.12,
                        filepath,
-                       JuicyPixels >= 3.1.5 && < 3.2,
+                       JuicyPixels >= 3.1.5 && < 3.3,
                        hashable >= 1.1 && < 1.3,
                        linear >= 1.11.3 && < 1.16,
                        adjunctions >= 4.0 && < 5.0,


### PR DESCRIPTION
New version is backward compatible with diagrams-lib usage.
