### PR TITLE
update for GHC-7.10, -Wall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
   global:
-    - HEAD_DEPS="diagrams-core diagrams-solve active"
+    - HEAD_DEPS="diagrams-core diagrams-solve active monoid-extras"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,19 @@ language: haskell
 
 env:
   matrix:
-    - HPVER=2013.2.0.0
-    - HPVER=2014.2.0.0
-    - GHCVER=7.4.2
-    - GHCVER=7.6.3
-    - GHCVER=7.8.4
-    - GHCVER=7.10.1
+    - HPVER=2013.2.0.0 CABALVER=1.18
+    - HPVER=2014.2.0.0 CABALVER=1.18
+    - GHCVER=7.4.2 CABALVER=1.18
+    - GHCVER=7.6.3 CABALVER=1.18
+    - GHCVER=7.8.4 CABALVER=1.18
+    - GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
   global:
-    - CABALVER=1.20
     - HEAD_DEPS="diagrams-core diagrams-solve active"
 
 matrix:
   allow_failures:
-    - env: GHCVER=7.10.1
-    - env: GHCVER=7.4.2
+    - env: GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
+    - env: GHCVER=7.4.2 CABALVER=1.18
 
 before_install:
   - git clone http://github.com/diagrams/diagrams-travis travis

--- a/src/Diagrams/Align.hs
+++ b/src/Diagrams/Align.hs
@@ -39,13 +39,14 @@ module Diagrams.Align
 import           Diagrams.Core
 import           Diagrams.Util (applyAll)
 
-import           Data.Maybe    (fromMaybe)
-import           Data.Ord      (comparing)
+import           Data.Maybe (fromMaybe)
+import           Data.Ord (comparing)
 import           Data.Traversable
+import           Prelude
 
 import qualified Data.Foldable as F
-import qualified Data.Map      as M
-import qualified Data.Set      as S
+import qualified Data.Map as M
+import qualified Data.Set as S
 
 import           Linear.Affine
 import           Linear.Metric
@@ -79,7 +80,7 @@ alignBy'Default boundary v d a = moveOriginTo (lerp ((d + 1) / 2)
                                                     (boundary (negated v) a)
                                               ) a
 {-# ANN alignBy'Default ("HLint: ignore Use camelCase" :: String) #-}
-                                              
+
 
 -- | Some standard functions which can be used as the `boundary` argument to
 --  `alignBy'`.
@@ -168,4 +169,3 @@ snugCenter = applyAll fs
     fs = map snugCenterV basis
 
 {-# ANN module ("HLint: ignore Use camelCase" :: String) #-}
-

--- a/src/Diagrams/Align.hs
+++ b/src/Diagrams/Align.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -37,16 +37,16 @@ module Diagrams.Align
        ) where
 
 import           Diagrams.Core
-import           Diagrams.Util (applyAll)
+import           Diagrams.Util    (applyAll)
 
-import           Data.Maybe (fromMaybe)
-import           Data.Ord (comparing)
+import           Data.Maybe       (fromMaybe)
+import           Data.Ord         (comparing)
 import           Data.Traversable
 import           Prelude
 
-import qualified Data.Foldable as F
-import qualified Data.Map as M
-import qualified Data.Set as S
+import qualified Data.Foldable    as F
+import qualified Data.Map         as M
+import qualified Data.Set         as S
 
 import           Linear.Affine
 import           Linear.Metric

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Angle
@@ -35,19 +35,19 @@ module Diagrams.Angle
        , HasPhi(..)
        ) where
 
-import Control.Applicative
-import Control.Lens (Iso', Lens', iso, review, (^.), over)
-import Data.Fixed
-import Data.Monoid hiding ((<>))
-import Data.Semigroup
-import Prelude
+import           Control.Applicative
+import           Control.Lens        (Iso', Lens', iso, over, review, (^.))
+import           Data.Fixed
+import           Data.Monoid         hiding ((<>))
+import           Data.Semigroup
+import           Prelude
 
-import Diagrams.Core.V
-import Diagrams.Core (OrderedField)
-import Diagrams.Points
+import           Diagrams.Core       (OrderedField)
+import           Diagrams.Core.V
+import           Diagrams.Points
 
-import Linear.Metric
-import Linear.Vector
+import           Linear.Metric
+import           Linear.Vector
 
 -- | Angles can be expressed in a variety of units.  Internally,
 --   they are represented in radians.

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -35,18 +35,19 @@ module Diagrams.Angle
        , HasPhi(..)
        ) where
 
-import           Control.Applicative
-import           Control.Lens        (Iso', Lens', iso, review, (^.), over)
-import           Data.Monoid         hiding ((<>))
-import           Data.Fixed
-import           Data.Semigroup
+import Control.Applicative
+import Control.Lens (Iso', Lens', iso, review, (^.), over)
+import Data.Fixed
+import Data.Monoid hiding ((<>))
+import Data.Semigroup
+import Prelude
 
-import           Diagrams.Core.V
-import           Diagrams.Core       (OrderedField)
-import           Diagrams.Points
+import Diagrams.Core.V
+import Diagrams.Core (OrderedField)
+import Diagrams.Points
 
-import           Linear.Metric
-import           Linear.Vector
+import Linear.Metric
+import Linear.Vector
 
 -- | Angles can be expressed in a variety of units.  Internally,
 --   they are represented in radians.
@@ -196,4 +197,3 @@ instance HasTheta v => HasTheta (Point v) where
 instance HasPhi v => HasPhi (Point v) where
   _phi = lensP . _phi
   {-# INLINE _phi #-}
-

--- a/src/Diagrams/Animation.hs
+++ b/src/Diagrams/Animation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -32,7 +33,9 @@ module Diagrams.Animation
 
 import           Control.Applicative       ((<$>))
 import           Data.Active
+#if __GLASGOW_HASKELL__ < 710
 import           Data.Foldable             (foldMap)
+#endif
 import           Data.Semigroup
 
 import           Diagrams.Core

--- a/src/Diagrams/Animation.hs
+++ b/src/Diagrams/Animation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/src/Diagrams/Animation.hs
+++ b/src/Diagrams/Animation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/src/Diagrams/Animation/Active.hs
+++ b/src/Diagrams/Animation/Active.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -37,7 +38,11 @@
 
 module Diagrams.Animation.Active where
 
+#if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative (pure, (<$>))
+#else
+import           Control.Applicative ((<$>))  -- should be in Prelude soon
+#endif
 
 import           Diagrams.Core
 import           Diagrams.TrailLike
@@ -98,4 +103,3 @@ instance Juxtaposable a => Juxtaposable (Active a) where
 
 -- instance Alignable a => Alignable (Active a) where
 --   alignBy v d a = alignBy v d <$> a
-

--- a/src/Diagrams/Deform.hs
+++ b/src/Diagrams/Deform.hs
@@ -11,20 +11,21 @@ module Diagrams.Deform
        , asDeformation
        ) where
 
-import           Control.Lens        (over, _Wrapped, mapped)
-import           Data.Monoid         hiding ((<>))
-import           Data.Semigroup
+import Control.Lens (over, _Wrapped, mapped)
+import Data.Monoid hiding ((<>))
+import Data.Semigroup
+import Prelude
 
-import           Diagrams.Core
-import           Diagrams.Located
-import           Diagrams.Parametric
-import           Diagrams.Path
-import           Diagrams.Segment
-import           Diagrams.Trail
+import Diagrams.Core
+import Diagrams.Located
+import Diagrams.Parametric
+import Diagrams.Path
+import Diagrams.Segment
+import Diagrams.Trail
 
-import           Linear.Affine
-import           Linear.Metric
-import           Linear.Vector
+import Linear.Affine
+import Linear.Metric
+import Linear.Vector
 
 ------------------------------------------------------------
 -- Deformations
@@ -124,4 +125,3 @@ instance (Metric v, Metric u, OrderedField n)
 instance (Metric v, Metric u, OrderedField n) => Deformable (Path v n) (Path u n) where
   deform' eps p = over (_Wrapped . mapped) (deform' eps p)
   deform p      = over (_Wrapped . mapped) (deform p)
-

--- a/src/Diagrams/Deform.hs
+++ b/src/Diagrams/Deform.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Diagrams.Deform
        ( Deformation(..)
@@ -11,21 +11,21 @@ module Diagrams.Deform
        , asDeformation
        ) where
 
-import Control.Lens (over, _Wrapped, mapped)
-import Data.Monoid hiding ((<>))
-import Data.Semigroup
-import Prelude
+import           Control.Lens        (mapped, over, _Wrapped)
+import           Data.Monoid         hiding ((<>))
+import           Data.Semigroup
+import           Prelude
 
-import Diagrams.Core
-import Diagrams.Located
-import Diagrams.Parametric
-import Diagrams.Path
-import Diagrams.Segment
-import Diagrams.Trail
+import           Diagrams.Core
+import           Diagrams.Located
+import           Diagrams.Parametric
+import           Diagrams.Path
+import           Diagrams.Segment
+import           Diagrams.Trail
 
-import Linear.Affine
-import Linear.Metric
-import Linear.Vector
+import           Linear.Affine
+import           Linear.Metric
+import           Linear.Vector
 
 ------------------------------------------------------------
 -- Deformations

--- a/src/Diagrams/Segment.hs
+++ b/src/Diagrams/Segment.hs
@@ -169,7 +169,7 @@ type instance V (Segment c v n) = v
 type instance N (Segment c v n) = n
 
 instance Transformable (Segment c v n) where
-	transform = mapSegmentVectors . apply
+    transform = mapSegmentVectors . apply
 
 instance Renderable (Segment c v n) NullBackend where
   render _ _ = mempty
@@ -530,4 +530,3 @@ instance (OrderedField n, Metric v)
                              (getEnvelope s)
 
            *: ()
-

--- a/src/Diagrams/Size.hs
+++ b/src/Diagrams/Size.hs
@@ -30,18 +30,18 @@ module Diagrams.Size
 
     -- ** Making size spec
   , mkSizeSpec
-	, dims
-	, absolute
+  , dims
+  , absolute
 
     -- ** Extracting size specs
-	, getSpec
+  , getSpec
   , specToSize
 
     -- ** Functions on size specs
-	, requiredScale
+  , requiredScale
   , requiredScaling
-	, sized
-	, sizedAs
+  , sized
+  , sizedAs
   , sizeAdjustment
   ) where
 
@@ -54,6 +54,7 @@ import           Data.Semigroup
 import           Data.Maybe
 import           Data.Typeable
 import           GHC.Generics        (Generic)
+import           Prelude
 
 import           Diagrams.Core
 import           Diagrams.BoundingBox
@@ -146,8 +147,8 @@ sizedAs :: (InSpace v n a, SameSpace a b, HasLinearMap v, HasBasis v, Transforma
         => b -> a -> a
 sizedAs other = sized (dims $ size other)
 
--- | Get the adjustment to fit a 'BoundingBox' in the given 'SizeSpec'. The 
---   vector is the new size and the transformation  to position the lower 
+-- | Get the adjustment to fit a 'BoundingBox' in the given 'SizeSpec'. The
+--   vector is the new size and the transformation  to position the lower
 --   corner at the origin and scale to the size spec.
 sizeAdjustment :: (Additive v, Foldable v, OrderedField n)
   => SizeSpec v n -> BoundingBox v n -> (v n, Transformation v n)
@@ -163,4 +164,3 @@ sizeAdjustment spec bb = (sz', t)
     s = requiredScale spec sz
 
     t = translation v <> scaling s
-

--- a/src/Diagrams/ThreeD/Transform.hs
+++ b/src/Diagrams/ThreeD/Transform.hs
@@ -104,12 +104,11 @@ aboutY (view rad -> a) = fromOrthogonal r where
 
 -- | @rotationAbout p d a@ is a rotation about a line parallel to @d@
 --   passing through @p@.
-rotationAbout
-  :: Floating n
-	=> Point V3 n         -- ^ origin of rotation
-  -> Direction V3 n     -- ^ direction of rotation axis
-  -> Angle n            -- ^ angle of rotation
-  -> Transformation V3 n
+rotationAbout :: Floating n
+                 => Point V3 n         -- ^ origin of rotation
+              -> Direction V3 n     -- ^ direction of rotation axis
+              -> Angle n            -- ^ angle of rotation
+              -> Transformation V3 n
 rotationAbout (P t) d (view rad -> a)
   = mconcat [translation (negated t),
              fromOrthogonal r,
@@ -130,7 +129,7 @@ rotationAbout (P t) d (view rad -> a)
 -- ± 1/4 turn.
 pointAt :: Floating n
         => Direction V3 n -> Direction V3 n -> Direction V3 n
-				-> Transformation V3 n
+        -> Transformation V3 n
 pointAt a i f = pointAt' (fromDirection a) (fromDirection i) (fromDirection f)
 
 -- | pointAt' has the same behavior as 'pointAt', but takes vectors
@@ -193,14 +192,13 @@ reflectionAcross :: (Metric v, R3 v, Fractional n)
   => Point v n -> v n -> Transformation v n
 reflectionAcross p v =
   conjugate (translation (origin .-. p)) reflect
-	  where
-			reflect = fromLinear t (linv t)
-			t       = f v <-> f (negated v)
-			f u w   = w ^-^ 2 *^ project u w
+  where
+    reflect = fromLinear t (linv t)
+    t       = f v <-> f (negated v)
+    f u w   = w ^-^ 2 *^ project u w
 
 -- | @reflectAcross p v@ reflects a diagram across the plane though
 --   the point @p@ and the vector @v@.
 reflectAcross :: (InSpace v n t, Metric v, R3 v, Fractional n, Transformable t)
   => Point v n -> v n -> t -> t
 reflectAcross p v = transform (reflectionAcross p v)
-

--- a/src/Diagrams/Transform/ScaleInv.hs
+++ b/src/Diagrams/Transform/ScaleInv.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -26,6 +27,9 @@ module Diagrams.Transform.ScaleInv
     where
 
 import           Control.Lens            (makeLenses, view, (^.))
+#if __GLASGOW_HASKELL__ < 710
+import           Data.Semigroup
+#endif
 import           Data.Typeable
 
 import           Diagrams.Angle

--- a/src/Diagrams/Transform/ScaleInv.hs
+++ b/src/Diagrams/Transform/ScaleInv.hs
@@ -26,7 +26,6 @@ module Diagrams.Transform.ScaleInv
     where
 
 import           Control.Lens            (makeLenses, view, (^.))
-import           Data.Semigroup
 import           Data.Typeable
 
 import           Diagrams.Angle

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -103,7 +104,9 @@ module Diagrams.TwoD.Arrow
        , module Diagrams.TwoD.Arrowheads
        ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative       ((<*>))
+#endif
 import           Control.Lens              (Lens', Setter', Traversal',
                                             generateSignatures, lensRules,
                                             makeLensesWith, view, (%~), (&),

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TypeFamilies              #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Arrowheads
@@ -340,4 +342,3 @@ quill = arrowtailQuill (2/5 @@ turn)
 --   > blockEx = drawTail block
 block :: RealFloat n => ArrowHT n
 block = arrowtailBlock (7/16 @@ turn)
-

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}

--- a/src/Diagrams/TwoD/Attributes.hs
+++ b/src/Diagrams/TwoD/Attributes.hs
@@ -120,7 +120,7 @@ type instance N (LGradient n) = n
 makeLensesWith (lensRules & generateSignatures .~ False) ''LGradient
 
 instance Fractional n => Transformable (LGradient n) where
-	transform = over lGradTrans . transform
+    transform = over lGradTrans . transform
 
 -- | A list of stops (colors and fractions).
 lGradStops :: Lens' (LGradient n) [GradientStop n]
@@ -413,4 +413,3 @@ splitTextureFills
 
                      , Typeable n) => RTree b v n a -> RTree b v n a
 splitTextureFills = splitAttr (FillTextureLoops :: FillTextureLoops n)
-

--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -42,6 +42,7 @@ module Diagrams.TwoD.Offset
 
 import           Control.Applicative
 import           Control.Lens            hiding (at)
+import           Prelude
 
 import           Data.Maybe              (catMaybes)
 import           Data.Monoid
@@ -558,4 +559,3 @@ joinSegmentIntersect miterLimit r e a b =
     miter v = abs (miterLimit * r) *^ v
     clip = joinSegmentClip miterLimit r e a b
     cross = let (xa,ya) = unr2 va; (xb,yb) = unr2 vb in abs (xa * yb - xb * ya)
-

--- a/src/Diagrams/TwoD/Polygons.hs
+++ b/src/Diagrams/TwoD/Polygons.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE ViewPatterns        #-}
-
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ViewPatterns          #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Polygons
@@ -47,34 +46,35 @@ module Diagrams.TwoD.Polygons(
 
     ) where
 
-import           Control.Lens            (Lens', generateSignatures, lensRules, makeLensesWith,
-                                          view, (.~), (^.))
-import Control.Monad (forM, liftM)
-import Control.Monad.ST (ST, runST)
-import Data.Array.ST (STUArray, newArray, readArray, writeArray)
-import Data.Default.Class
-import Data.List (maximumBy, minimumBy)
-import Data.Maybe (catMaybes)
+import           Control.Lens            (Lens', generateSignatures, lensRules,
+                                          makeLensesWith, view, (.~), (^.))
+import           Control.Monad           (forM, liftM)
+import           Control.Monad.ST        (ST, runST)
+import           Data.Array.ST           (STUArray, newArray, readArray,
+                                          writeArray)
+import           Data.Default.Class
+import           Data.List               (maximumBy, minimumBy)
+import           Data.Maybe              (catMaybes)
 #if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mconcat, mempty)
+import           Data.Monoid             (mconcat, mempty)
 #endif
-import Data.Ord (comparing)
+import           Data.Ord                (comparing)
 
-import Diagrams.Angle
-import Diagrams.Core
-import Diagrams.Located
-import Diagrams.Path
-import Diagrams.Points (centroid)
-import Diagrams.Trail
-import Diagrams.TrailLike
-import Diagrams.TwoD.Transform
-import Diagrams.TwoD.Types
-import Diagrams.TwoD.Vector (leftTurn, unitX, unitY, unit_Y)
-import Diagrams.Util (tau, ( # ))
+import           Diagrams.Angle
+import           Diagrams.Core
+import           Diagrams.Located
+import           Diagrams.Path
+import           Diagrams.Points         (centroid)
+import           Diagrams.Trail
+import           Diagrams.TrailLike
+import           Diagrams.TwoD.Transform
+import           Diagrams.TwoD.Types
+import           Diagrams.TwoD.Vector    (leftTurn, unitX, unitY, unit_Y)
+import           Diagrams.Util           (tau, ( # ))
 
-import Linear.Affine
-import Linear.Metric
-import Linear.Vector
+import           Linear.Affine
+import           Linear.Metric
+import           Linear.Vector
 
 -- | Method used to determine the vertices of a polygon.
 data PolyType n = PolyPolar [Angle n] [n]

--- a/src/Diagrams/TwoD/Polygons.hs
+++ b/src/Diagrams/TwoD/Polygons.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE FlexibleContexts    #-}
@@ -48,30 +49,32 @@ module Diagrams.TwoD.Polygons(
 
 import           Control.Lens            (Lens', generateSignatures, lensRules, makeLensesWith,
                                           view, (.~), (^.))
-import           Control.Monad           (forM, liftM)
-import           Control.Monad.ST        (ST, runST)
-import           Data.Array.ST           (STUArray, newArray, readArray, writeArray)
-import           Data.Default.Class
-import           Data.List               (maximumBy, minimumBy)
-import           Data.Maybe              (catMaybes)
-import           Data.Monoid             (mconcat, mempty)
-import           Data.Ord                (comparing)
+import Control.Monad (forM, liftM)
+import Control.Monad.ST (ST, runST)
+import Data.Array.ST (STUArray, newArray, readArray, writeArray)
+import Data.Default.Class
+import Data.List (maximumBy, minimumBy)
+import Data.Maybe (catMaybes)
+#if __GLASGOW_HASKELL__ < 710
+import Data.Monoid (mconcat, mempty)
+#endif
+import Data.Ord (comparing)
 
-import           Diagrams.Angle
-import           Diagrams.Core
-import           Diagrams.Located
-import           Diagrams.Path
-import           Diagrams.Points         (centroid)
-import           Diagrams.Trail
-import           Diagrams.TrailLike
-import           Diagrams.TwoD.Transform
-import           Diagrams.TwoD.Types
-import           Diagrams.TwoD.Vector    (leftTurn, unitX, unitY, unit_Y)
-import           Diagrams.Util           (tau, ( # ))
+import Diagrams.Angle
+import Diagrams.Core
+import Diagrams.Located
+import Diagrams.Path
+import Diagrams.Points (centroid)
+import Diagrams.Trail
+import Diagrams.TrailLike
+import Diagrams.TwoD.Transform
+import Diagrams.TwoD.Types
+import Diagrams.TwoD.Vector (leftTurn, unitX, unitY, unit_Y)
+import Diagrams.Util (tau, ( # ))
 
-import           Linear.Affine
-import           Linear.Metric
-import           Linear.Vector
+import Linear.Affine
+import Linear.Metric
+import Linear.Vector
 
 -- | Method used to determine the vertices of a polygon.
 data PolyType n = PolyPolar [Angle n] [n]
@@ -98,7 +101,7 @@ data PolyType n = PolyPolar [Angle n] [n]
                 --   words, a polygon specified by \"turtle
                 --   graphics\": go straight ahead x1 units; turn by
                 --   external angle a1; go straight ahead x2 units; turn by
-                --   external angle a2; etc. The polygon will be centered 
+                --   external angle a2; etc. The polygon will be centered
                 --   at the /centroid/ of its vertices.
                 --
                 --   * The first argument is a list of /vertex/

--- a/src/Diagrams/TwoD/Segment/Bernstein.hs
+++ b/src/Diagrams/TwoD/Segment/Bernstein.hs
@@ -3,13 +3,13 @@
 
 module Diagrams.TwoD.Segment.Bernstein
   ( BernsteinPoly (..)
-	, listToBernstein
-	, evaluateBernstein
+  , listToBernstein
+  , evaluateBernstein
 
-	, degreeElevate
-	, bernsteinDeriv
-	, evaluateBernsteinDerivs
-	) where
+  , degreeElevate
+  , bernsteinDeriv
+  , evaluateBernsteinDerivs
+  ) where
 
 import           Data.List           (tails)
 import           Diagrams.Core.V
@@ -78,12 +78,12 @@ bernsteinDeriv (BernsteinPoly lp p) =
   BernsteinPoly (lp-1) $ zipWith (\a b -> (a - b) * fromIntegral lp) (tail p) p
 
 instance Fractional n => Parametric (BernsteinPoly n) where
-	atParam b = V1 . evaluateBernstein b
+    atParam b = V1 . evaluateBernstein b
 instance Num n        => DomainBounds (BernsteinPoly n)
 instance Fractional n => EndValues    (BernsteinPoly n)
 instance Fractional n => Sectionable  (BernsteinPoly n) where
-	splitAtParam  = bernsteinSplit
-	reverseDomain (BernsteinPoly i xs) = BernsteinPoly i (reverse xs)
+    splitAtParam  = bernsteinSplit
+    reverseDomain (BernsteinPoly i xs) = BernsteinPoly i (reverse xs)
 
 -- | Split a bernstein polynomial
 bernsteinSplit :: Num n => BernsteinPoly n -> n -> (BernsteinPoly n, BernsteinPoly n)
@@ -114,7 +114,7 @@ instance Fractional n => Num (BernsteinPoly n) where
     zipWith (flip (/)) (binomials (la + lb)) $
                    init $ map sum $
                    map (zipWith (*) a') (down b') ++
-									 map (zipWith (*) (reverse b')) (tail $ tails a')
+                   map (zipWith (*) (reverse b')) (tail $ tails a')
                    -- zipWith (zipWith (*)) (tail $ tails a') (repeat $ reverse b')
     where down l = tail $ scanl (flip (:)) [] l -- [[1], [2, 1], [3, 2, 1], ...
           a' = zipWith (*) a (binomials la)
@@ -126,5 +126,3 @@ instance Fractional n => Num (BernsteinPoly n) where
   signum (BernsteinPoly _ (a:_)) = BernsteinPoly 0 [signum a]
 
   abs = fmap abs
-
-


### PR DESCRIPTION
- remove tabs
- handle extra imports of Foldable, Traversable, Monoid By some
  combination of the `import Prelude` hack, where effective, CPP, and
  `-fno-warn`.