### PR TITLE
updated changes for GHC-7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
   global:
-    - HEAD_DEPS="diagrams-core diagrams-solve active"
+    - HEAD_DEPS="diagrams-core diagrams-solve active monoid-extras dual-tree"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,19 @@ language: haskell
 
 env:
   matrix:
-    - HPVER=2013.2.0.0
-    - HPVER=2014.2.0.0
-    - GHCVER=7.4.2
-    - GHCVER=7.6.3
-    - GHCVER=7.8.4
-    - GHCVER=7.10.1
+    - HPVER=2013.2.0.0 CABALVER=1.18
+    - HPVER=2014.2.0.0 CABALVER=1.18
+    - GHCVER=7.4.2 CABALVER=1.18
+    - GHCVER=7.6.3 CABALVER=1.18
+    - GHCVER=7.8.4 CABALVER=1.18
+    - GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
   global:
-    - CABALVER=1.20
     - HEAD_DEPS="diagrams-core diagrams-solve active"
 
 matrix:
   allow_failures:
-    - env: GHCVER=7.10.1
-    - env: GHCVER=7.4.2
+    - env: GHCVER=7.10.1 SKIP_HADDOCK=true CABALVER=1.22
+    - env: GHCVER=7.4.2 CABALVER=1.18
 
 before_install:
   - git clone http://github.com/diagrams/diagrams-travis travis

--- a/src/Diagrams/Align.hs
+++ b/src/Diagrams/Align.hs
@@ -36,15 +36,16 @@ module Diagrams.Align
        ) where
 
 import           Diagrams.Core
-import           Diagrams.Util (applyAll)
+import           Diagrams.Util    (applyAll)
 
-import           Data.Maybe    (fromMaybe)
-import           Data.Ord      (comparing)
+import           Data.Maybe       (fromMaybe)
+import           Data.Ord         (comparing)
 import           Data.Traversable
+import           Prelude
 
-import qualified Data.Foldable as F
-import qualified Data.Map      as M
-import qualified Data.Set      as S
+import qualified Data.Foldable    as F
+import qualified Data.Map         as M
+import qualified Data.Set         as S
 
 import           Linear.Affine
 import           Linear.Metric
@@ -167,4 +168,3 @@ snugCenter = applyAll fs
     fs = map snugCenterV basis
 
 {-# ANN module ("HLint: ignore Use camelCase" :: String) #-}
-

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Angle
@@ -36,13 +36,14 @@ module Diagrams.Angle
        ) where
 
 import           Control.Applicative
-import           Control.Lens        (Iso', Lens', iso, review, (^.), over)
-import           Data.Monoid         hiding ((<>))
+import           Control.Lens        (Iso', Lens', iso, over, review, (^.))
 import           Data.Fixed
+import           Data.Monoid         hiding ((<>))
 import           Data.Semigroup
+import           Prelude
 
-import           Diagrams.Core.V
 import           Diagrams.Core       (OrderedField)
+import           Diagrams.Core.V
 import           Diagrams.Points
 
 import           Linear.Metric
@@ -196,4 +197,3 @@ instance HasTheta v => HasTheta (Point v) where
 instance HasPhi v => HasPhi (Point v) where
   _phi = lensP . _phi
   {-# INLINE _phi #-}
-

--- a/src/Diagrams/Animation.hs
+++ b/src/Diagrams/Animation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -31,7 +32,9 @@ module Diagrams.Animation
 
 import           Control.Applicative       ((<$>))
 import           Data.Active
+#if __GLASGOW_HASKELL__ < 710
 import           Data.Foldable             (foldMap)
+#endif
 import           Data.Semigroup
 
 import           Diagrams.Core

--- a/src/Diagrams/Animation/Active.hs
+++ b/src/Diagrams/Animation/Active.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -37,7 +38,11 @@
 
 module Diagrams.Animation.Active where
 
+#if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative (pure, (<$>))
+#else
+import           Control.Applicative ((<$>))  -- should be in Prelude soon
+#endif
 
 import           Diagrams.Core
 import           Diagrams.TrailLike
@@ -98,4 +103,3 @@ instance Juxtaposable a => Juxtaposable (Active a) where
 
 -- instance Alignable a => Alignable (Active a) where
 --   alignBy v d a = alignBy v d <$> a
-

--- a/src/Diagrams/Deform.hs
+++ b/src/Diagrams/Deform.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Diagrams.Deform
        ( Deformation(..)
@@ -11,9 +11,10 @@ module Diagrams.Deform
        , asDeformation
        ) where
 
-import           Control.Lens        (over, _Wrapped, mapped)
+import           Control.Lens        (mapped, over, _Wrapped)
 import           Data.Monoid         hiding ((<>))
 import           Data.Semigroup
+import           Prelude
 
 import           Diagrams.Core
 import           Diagrams.Located
@@ -124,4 +125,3 @@ instance (Metric v, Metric u, OrderedField n, r ~ Located (Trail u n))
 instance (Metric v, Metric u, OrderedField n, r ~ Path u n) => Deformable (Path v n) r where
   deform' eps p = over (_Wrapped . mapped) (deform' eps p)
   deform p      = over (_Wrapped . mapped) (deform p)
-

--- a/src/Diagrams/LinearMap.hs
+++ b/src/Diagrams/LinearMap.hs
@@ -24,7 +24,7 @@ module Diagrams.LinearMap where
 
 import           Control.Lens
 import           Data.FingerTree         as FT
-import           Data.Foldable           (Foldable)
+import qualified Data.Foldable as F
 
 import           Diagrams.Core
 import           Diagrams.Core.Transform
@@ -59,7 +59,7 @@ class LinearMappable a b where
 -- so ghc knows there's only one possible result from calling vmap.
 
 -- | Apply a linear map.
-linmap :: (InSpace v n a, Foldable v, LinearMappable a b, N b ~ n)
+linmap :: (InSpace v n a, F.Foldable v, LinearMappable a b, N b ~ n)
      => LinearMap v (V b) n -> a -> b
 linmap = vmap . lapply
 
@@ -122,7 +122,7 @@ toAffineMap :: (HasBasis v, Num n)
 toAffineMap t = AffineMap (toLinearMap t) (transl t)
 
 class (LinearMappable a b, N a ~ N b) => AffineMappable a b where
-  amap :: (Additive (V a), Foldable (V a), Additive (V b), Num (N b))
+  amap :: (Additive (V a), F.Foldable (V a), Additive (V b), Num (N b))
        => AffineMap (V a) (V b) (N b) -> a -> b
   amap (AffineMap f _) = linmap f
   {-# INLINE amap #-}
@@ -133,7 +133,7 @@ instance (Metric v, Metric u, OrderedField n, r ~ SegTree u n) => AffineMappable
 instance (Metric v, Metric u, OrderedField n, r ~ Trail' l u n) => AffineMappable (Trail' l v n) r
 instance (Metric v, Metric u, OrderedField n, r ~ Trail u n) => AffineMappable (Trail v n) r
 
-instance (Additive v, Foldable v, Num n, r ~ Point u n) => AffineMappable (Point v n) r where
+instance (Additive v, F.Foldable v, Num n, r ~ Point u n) => AffineMappable (Point v n) r where
   amap (AffineMap f v) p = linmap f p .+^ v
   {-# INLINE amap #-}
 
@@ -150,4 +150,3 @@ instance (Metric v, Metric u, OrderedField n, r ~ Path u n)
     => AffineMappable (Path v n) r where
   amap m = _Wrapped . mapped %~ amap m
   {-# INLINE amap #-}
-

--- a/src/Diagrams/Size.hs
+++ b/src/Diagrams/Size.hs
@@ -53,6 +53,7 @@ import           Data.Semigroup
 import           Data.Maybe
 import           Data.Typeable
 import           GHC.Generics        (Generic)
+import           Prelude
 
 import           Diagrams.Core
 import           Diagrams.BoundingBox
@@ -162,4 +163,3 @@ sizeAdjustment spec bb = (sz', t)
     s = requiredScale spec sz
 
     t = translation v <> scaling s
-

--- a/src/Diagrams/ThreeD/Transform.hs
+++ b/src/Diagrams/ThreeD/Transform.hs
@@ -103,12 +103,11 @@ aboutY (view rad -> a) = fromOrthogonal r where
 
 -- | @rotationAbout p d a@ is a rotation about a line parallel to @d@
 --   passing through @p@.
-rotationAbout
-  :: Floating n
-	=> Point V3 n         -- ^ origin of rotation
-  -> Direction V3 n     -- ^ direction of rotation axis
-  -> Angle n            -- ^ angle of rotation
-  -> Transformation V3 n
+rotationAbout :: Floating n
+                 => Point V3 n         -- ^ origin of rotation
+              -> Direction V3 n     -- ^ direction of rotation axis
+              -> Angle n            -- ^ angle of rotation
+              -> Transformation V3 n
 rotationAbout (P t) d (view rad -> a)
   = mconcat [translation (negated t),
              fromOrthogonal r,
@@ -202,4 +201,3 @@ reflectionAcross p v =
 reflectAcross :: (InSpace v n t, Metric v, R3 v, Fractional n, Transformable t)
   => Point v n -> v n -> t -> t
 reflectAcross p v = transform (reflectionAcross p v)
-

--- a/src/Diagrams/Transform/Matrix.hs
+++ b/src/Diagrams/Transform/Matrix.hs
@@ -15,7 +15,7 @@ import           Control.Applicative
 import           Control.Arrow ((&&&))
 import           Control.Lens
 import           Data.Distributive
-import           Data.Foldable
+import qualified Data.Foldable as F
 import           Data.Functor.Rep
 
 import           Diagrams.Core.Transform as D
@@ -41,7 +41,7 @@ fromMat33 :: (Epsilon n, Floating n) => M33 n -> V3 n -> Maybe (T3 n)
 fromMat33 m v = flip (fromMatWithInv m) v <$> inv33 m
 
 -- | Build a transform with a maxtrix along with its inverse.
-fromMatWithInv :: (Additive v, Distributive v, Foldable v, Num n)
+fromMatWithInv :: (Additive v, Distributive v, F.Foldable v, Num n)
   => v (v n) -- ^ matrix
   -> v (v n) -- ^ inverse
   -> v n     -- ^ translation
@@ -57,4 +57,3 @@ mat22 = prism' (mkMat &&& transl) (uncurry fromMat22)
 
 mat33 :: (Epsilon n, Floating n) => Prism' (M33 n, V3 n) (T3 n)
 mat33 = prism' (mkMat &&& transl) (uncurry fromMat33)
-

--- a/src/Diagrams/Transform/ScaleInv.hs
+++ b/src/Diagrams/Transform/ScaleInv.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -26,7 +27,9 @@ module Diagrams.Transform.ScaleInv
     where
 
 import           Control.Lens            (makeLenses, view, (^.))
+#if __GLASGOW_HASKELL__ < 710
 import           Data.Semigroup
+#endif
 import           Data.Typeable
 
 import           Diagrams.Angle

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -103,8 +104,13 @@ module Diagrams.TwoD.Arrow
        , module Diagrams.TwoD.Arrowheads
        ) where
 
-import           Control.Applicative      ((<*>))
-import           Control.Lens             hiding (transform, none, (#))
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative       ((<*>))
+#endif
+import           Control.Lens              (Lens', Traversal',
+                                            generateSignatures, lensRules,
+                                            makeLensesWith, view, (%~), (&),
+                                            (.~), (^.))
 import           Data.Default.Class
 import           Data.Functor              ((<$>))
 import           Data.Maybe                (fromMaybe)

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TypeFamilies              #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.TwoD.Arrowheads

--- a/src/Diagrams/TwoD/Attributes.hs
+++ b/src/Diagrams/TwoD/Attributes.hs
@@ -424,4 +424,3 @@ splitTextureFills
 
                      , Typeable n) => RTree b v n a -> RTree b v n a
 splitTextureFills = splitAttr (FillTextureLoops :: FillTextureLoops n)
-

--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -42,6 +42,7 @@ module Diagrams.TwoD.Offset
 
 import           Control.Applicative
 import           Control.Lens            hiding (at)
+import           Prelude
 
 import           Data.Maybe              (catMaybes)
 import           Data.Monoid
@@ -558,4 +559,3 @@ joinSegmentIntersect miterLimit r e a b =
     miter v = abs (miterLimit * r) *^ v
     clip = joinSegmentClip miterLimit r e a b
     cross = let (xa,ya) = unr2 va; (xb,yb) = unr2 vb in abs (xa * yb - xb * ya)
-

--- a/src/Diagrams/TwoD/Polygons.hs
+++ b/src/Diagrams/TwoD/Polygons.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP       #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -45,15 +46,18 @@ module Diagrams.TwoD.Polygons(
 
     ) where
 
-import           Control.Lens            (Lens', generateSignatures, lensRules, makeLensesWith,
-                                          view, (.~), (^.))
+import           Control.Lens            (Lens', generateSignatures, lensRules,
+                                          makeLensesWith, view, (.~), (^.))
 import           Control.Monad           (forM, liftM)
 import           Control.Monad.ST        (ST, runST)
-import           Data.Array.ST           (STUArray, newArray, readArray, writeArray)
+import           Data.Array.ST           (STUArray, newArray, readArray,
+                                          writeArray)
 import           Data.Default.Class
 import           Data.List               (maximumBy, minimumBy)
 import           Data.Maybe              (catMaybes)
+#if __GLASGOW_HASKELL__ < 710
 import           Data.Monoid             (mconcat, mempty)
+#endif
 import           Data.Ord                (comparing)
 
 import           Diagrams.Angle

--- a/src/Diagrams/TwoD/Segment/Bernstein.hs
+++ b/src/Diagrams/TwoD/Segment/Bernstein.hs
@@ -126,4 +126,3 @@ instance Fractional n => Num (BernsteinPoly n) where
   signum (BernsteinPoly _ (a:_)) = BernsteinPoly 0 [signum a]
 
   abs = fmap abs
-


### PR DESCRIPTION
This supercedes https://github.com/diagrams/diagrams-lib/pull/238

Compared to that PR:
- it is rebased onto master
- several commits are squashed to avoid spurious whitespace changes
- changes from the `travis` branch are included

I've built it locally with GHC-7.10, but haven't updated the `travis`
branch since rebasing.