### PR TITLE
Pre 1.3

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -110,7 +110,7 @@ Library
                        data-default-class < 0.1,
                        fingertree >= 0.1 && < 0.2,
                        intervals >= 0.7 && < 0.8,
-                       lens >= 4.6 && < 4.8,
+                       lens >= 4.6 && < 4.9,
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.12,
                        filepath,

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -25,7 +25,8 @@ Source-repository head
   location: http://github.com/diagrams/diagrams-lib.git
 
 Library
-  Exposed-modules:     Diagrams.Prelude,
+  Exposed-modules:     Diagrams,
+                       Diagrams.Prelude,
                        Diagrams.Align,
                        Diagrams.Angle,
                        Diagrams.Animation,

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -109,7 +109,7 @@ Library
                        data-default-class < 0.1,
                        fingertree >= 0.1 && < 0.2,
                        intervals >= 0.7 && < 0.8,
-                       lens >= 4.0 && < 4.8,
+                       lens >= 4.6 && < 4.8,
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.12,
                        filepath,

--- a/src/Diagrams.hs
+++ b/src/Diagrams.hs
@@ -1,0 +1,150 @@
+{-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams
+-- Copyright   :  (c) 2015 diagrams-lib team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- This module only contains exports defined in "diagrams-lib" or
+-- "diagrams-core". This module is less likely conflict with any
+-- other modules but importing "Diagrams.Prelude" is often more convenient.
+--
+-----------------------------------------------------------------------------
+
+module Diagrams
+  (
+    -- * Core library
+    -- | The core definitions of transformations, diagrams,
+    --   backends, and so on.
+    module Diagrams.Core
+
+    -- * Standard library
+
+    -- | Attributes (color, line style, etc.) and styles.
+  , module Diagrams.Attributes
+
+    -- | Alignment of diagrams relative to their envelopes.
+  , module Diagrams.Align
+
+    -- | Creating and using bounding boxes.
+  , module Diagrams.BoundingBox
+
+    -- | Combining multiple diagrams into one.
+  , module Diagrams.Combinators
+
+    -- | Giving concrete locations to translation-invariant things.
+  , module Diagrams.Located
+
+    -- | Linear and cubic bezier segments.
+  , module Diagrams.Segment
+
+    -- | Trails.
+  , module Diagrams.Trail
+
+    -- | Parametrization of segments and trails.
+  , module Diagrams.Parametric
+
+    -- | Adjusting the length of parameterized objects.
+  , module Diagrams.Parametric.Adjust
+
+    -- | Computing tangent and normal vectors of segments and
+    --   trails.
+  , module Diagrams.Tangent
+
+    -- | Trail-like things.
+  , module Diagrams.TrailLike
+
+    -- | Paths.
+  , module Diagrams.Path
+
+    -- | Cubic splines.
+  , module Diagrams.CubicSpline
+
+    -- | Some additional transformation-related functions, like
+    --   conjugation of transformations.
+  , module Diagrams.Transform
+
+    -- | Projective transformations and other deformations
+    -- lacking an inverse.
+  , module Diagrams.Deform
+
+    -- | Giving names to subdiagrams and later retrieving
+    --   subdiagrams by name.
+  , module Diagrams.Names
+
+    -- | Envelopes, aka functional bounding regions.
+  , module Diagrams.Envelope
+
+    -- | Traces, aka embedded raytracers, for finding points on
+    --   the boundary of a diagram.
+  , module Diagrams.Trace
+
+    -- | A query is a function that maps points in a vector space
+    --   to values in some monoid; they can be used to annotate
+    --   the points of a diagram with some values.
+  , module Diagrams.Query
+
+    -- | Utilities for working with points.
+  , module Diagrams.Points
+
+    -- | Utilities for working with size.
+  , module Diagrams.Size
+
+    -- | Angles
+  , module Diagrams.Angle
+
+    -- | Convenience infix operators for working with coordinates.
+  , module Diagrams.Coordinates
+
+    -- | Directions, distinguished from angles or vectors
+  , module Diagrams.Direction
+
+    -- | A wide range of things (shapes, transformations,
+    --   combinators) specific to creating two-dimensional
+    --   diagrams.
+  , module Diagrams.TwoD
+
+    -- | Extra things for three-dimensional diagrams.
+  , module Diagrams.ThreeD
+
+    -- | Tools for making animations.
+  , module Diagrams.Animation
+
+    -- | Various utility definitions.
+  , module Diagrams.Util
+
+  ) where
+
+import           Diagrams.Core
+
+import           Diagrams.Align
+import           Diagrams.Angle
+import           Diagrams.Animation
+import           Diagrams.Attributes
+import           Diagrams.BoundingBox       hiding (intersection, union, inside, outside, contains)
+import           Diagrams.Combinators
+import           Diagrams.Coordinates
+import           Diagrams.CubicSpline
+import           Diagrams.Deform
+import           Diagrams.Direction         hiding (dir)
+import           Diagrams.Envelope
+import           Diagrams.Located
+import           Diagrams.Names
+import           Diagrams.Parametric
+import           Diagrams.Parametric.Adjust
+import           Diagrams.Path
+import           Diagrams.Points
+import           Diagrams.Query
+import           Diagrams.Segment
+import           Diagrams.Size
+import           Diagrams.Tangent
+import           Diagrams.ThreeD
+import           Diagrams.Trace
+import           Diagrams.Trail             hiding (linePoints, loopPoints,
+                                             trailPoints)
+import           Diagrams.TrailLike
+import           Diagrams.Transform
+import           Diagrams.TwoD
+import           Diagrams.Util
+

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -40,6 +40,7 @@ import           Control.Lens        (Iso', Lens', iso, review, (^.), over)
 import           Data.Monoid         hiding ((<>))
 import           Data.Fixed
 import           Data.Semigroup
+import           Text.Read
 
 import           Diagrams.Core.V
 import           Diagrams.Core       (OrderedField)
@@ -51,7 +52,18 @@ import           Linear.Vector
 -- | Angles can be expressed in a variety of units.  Internally,
 --   they are represented in radians.
 newtype Angle n = Radians n
-  deriving (Read, Show, Eq, Ord, Enum, Functor)
+  deriving (Eq, Ord, Enum, Functor)
+
+instance Show n => Show (Angle n) where
+  showsPrec d (Radians a) = showParen (d > 5) $
+    showsPrec 6 a . showString " @@ rad"
+
+instance Read n => Read (Angle n) where
+  readPrec = parens . prec 5 $ do
+    x <- readPrec
+    Symbol "@@" <- lexP
+    Ident "rad" <- lexP
+    pure (Radians x)
 
 type instance N (Angle n) = n
 

--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -36,7 +36,7 @@ module Diagrams.Angle
        ) where
 
 import           Control.Applicative
-import           Control.Lens        (Iso', Lens', iso, over, review, (^.))
+import           Control.Lens        (AReview, Iso', Lens', iso, over, review, (^.))
 import           Data.Fixed
 import           Data.Monoid         hiding ((<>))
 import           Data.Semigroup
@@ -86,21 +86,22 @@ instance Num n => Monoid (Angle n) where
   mappend = (<>)
   mempty  = Radians 0
 
--- | The radian measure of an @Angle@ @a@ can be accessed as @a
---   ^. rad@.  A new @Angle@ can be defined in radians as @pi \@\@ rad@.
+-- | The radian measure of an 'Angle' @a@ can be accessed as @a '^.'
+--   rad@. A new 'Angle' can be defined in radians as @pi \@\@
+--   rad@.
 rad :: Iso' (Angle n) n
 rad = iso (\(Radians r) -> r) Radians
 {-# INLINE rad #-}
 
--- | The measure of an @Angle@ @a@ in full circles can be accessed as
---   @a ^. turn@.  A new @Angle@ of one-half circle can be defined in as
+-- | The measure of an 'Angle' @a@ in full circles can be accessed as
+--   @a '^.' turn@.  A new 'Angle' of one-half circle can be defined in as
 --   @1/2 \@\@ turn@.
 turn :: Floating n => Iso' (Angle n) n
 turn = iso (\(Radians r) -> r / (2*pi)) (Radians . (*(2*pi)))
 {-# INLINE turn #-}
 
--- | The degree measure of an @Angle@ @a@ can be accessed as @a
---   ^. deg@.  A new @Angle@ can be defined in degrees as @180 \@\@
+-- | The degree measure of an 'Angle' @a@ can be accessed as @a
+--   '^.' deg@. A new 'Angle' can be defined in degrees as @180 \@\@
 --   deg@.
 deg :: Floating n => Iso' (Angle n) n
 deg = iso (\(Radians r) -> r / (2*pi/360)) (Radians . ( * (2*pi/360)))
@@ -153,7 +154,7 @@ atan2A y x = Radians $ atan2 y x
 
 -- | Similar to 'atan2A' but without the 'RealFloat' constraint. This means it
 --   doesn't handle negative zero cases. However, for most geometric purposes,
---   outcome will be the same.
+--   the outcome will be the same.
 atan2A' :: OrderedField n => n -> n -> Angle n
 atan2A' y x = atan2' y x @@ rad
 
@@ -168,13 +169,30 @@ atan2' y x
   | x==0 && y==0     =  y     -- must be after the other double zero tests
   | otherwise        =  x + y -- x or y is a NaN, return a NaN (via +)
 
--- | @30 \@\@ deg@ is an @Angle@ of the given measure and units.
+-- | @30 \@\@ deg@ is an 'Angle' of the given measure and units.
 --
---   More generally, @\@\@@ reverses the @Iso\'@ on its right, and
---   applies the @Iso\'@ to the value on the left.  @Angle@s are the
---   motivating example where this order improves readability.
-(@@) :: b -> Iso' a b -> a
--- The signature above is slightly specialized, in favor of readability
+-- >>> pi @@ rad
+-- 3.141592653589793 @@ rad
+--
+-- >>> 1 @@ turn
+-- 6.283185307179586 @@ rad
+--
+-- >>> 30 @@ deg
+-- 0.5235987755982988 @@ rad
+--
+--   For 'Iso''s, ('@@') reverses the 'Iso'' on its right, and applies
+--   the 'Iso'' to the value on the left. 'Angle's are the motivating
+--   example where this order improves readability.
+--
+--   This is the same as a flipped 'review'.
+--
+-- @
+-- ('@@') :: a -> 'Iso''      s a -> s
+-- ('@@') :: a -> 'Prism''    s a -> s
+-- ('@@') :: a -> 'Review'    s a -> s
+-- ('@@') :: a -> 'Equality'' s a -> s
+-- @
+(@@) :: b -> AReview a b -> a
 a @@ i = review i a
 
 infixl 5 @@
@@ -192,12 +210,12 @@ normalizeAngle = over rad (`mod'` (2 * pi))
 ------------------------------------------------------------
 -- Polar Coordinates
 
--- | The class of types with at least one angle coordinate, called _theta.
+-- | The class of types with at least one angle coordinate, called '_theta'.
 class HasTheta t where
   _theta :: RealFloat n => Lens' (t n) (Angle n)
 
 -- | The class of types with at least two angle coordinates, the second called
---   _phi. _phi is the positive angle measured from the z axis.
+--   '_phi'. '_phi' is the positive angle measured from the z axis.
 class HasTheta t => HasPhi t where
   _phi :: RealFloat n => Lens' (t n) (Angle n)
 

--- a/src/Diagrams/Attributes.hs
+++ b/src/Diagrams/Attributes.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE ViewPatterns               #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Attributes
@@ -252,6 +253,18 @@ class Color c where
 -- | An existential wrapper for instances of the 'Color' class.
 data SomeColor = forall c. Color c => SomeColor c
   deriving Typeable
+
+instance Show SomeColor where
+  showsPrec d (colorToSRGBA -> (r,g,b,a)) =
+    showParen (d > 10) $ showString "SomeColor " .
+      if a == 0
+        then showString "transparent"
+        else showString "(sRGB " . showsPrec 11 r . showChar ' '
+                                 . showsPrec 11 g . showChar ' '
+                                 . showsPrec 11 b .
+                        (if a /= 1
+                           then showString " `withOpacity` " . showsPrec 11 a
+                           else id) . showChar ')'
 
 -- | Isomorphism between 'SomeColor' and 'AlphaColour' 'Double'.
 _SomeColor :: Iso' SomeColor (AlphaColour Double)

--- a/src/Diagrams/Attributes.hs
+++ b/src/Diagrams/Attributes.hs
@@ -339,12 +339,14 @@ data LineCap = LineCapButt   -- ^ Lines end precisely at their endpoints.
                              --   centered on endpoints.
              | LineCapSquare -- ^ Lines are capped with a squares
                              --   centered on endpoints.
-  deriving (Eq,Show,Typeable)
+  deriving (Eq, Ord, Show, Typeable)
 
 instance Default LineCap where
   def = LineCapButt
 
 instance AttributeClass LineCap
+
+-- | Last semigroup structure.
 instance Semigroup LineCap where
   _ <> b = b
 
@@ -367,9 +369,11 @@ data LineJoin = LineJoinMiter    -- ^ Use a \"miter\" shape (whatever that is).
               | LineJoinBevel    -- ^ Use a \"bevel\" shape (whatever
                                  --   that is).  Are these...
                                  --   carpentry terms?
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Ord, Show, Typeable)
 
 instance AttributeClass LineJoin
+
+-- | Last semigroup structure.
 instance Semigroup LineJoin where
   _ <> b = b
 
@@ -392,7 +396,7 @@ _lineJoin = atAttr . non def
 -- | Miter limit attribute affecting the 'LineJoinMiter' joins.
 --   For some backends this value may have additional effects.
 newtype LineMiterLimit = LineMiterLimit (Last Double)
-  deriving (Typeable, Semigroup, Eq)
+  deriving (Typeable, Semigroup, Eq, Ord)
 instance AttributeClass LineMiterLimit
 
 _LineMiterLimit :: Iso' LineMiterLimit Double

--- a/src/Diagrams/Attributes.hs
+++ b/src/Diagrams/Attributes.hs
@@ -260,13 +260,13 @@ _SomeColor = iso toAlphaColour fromAlphaColour
 someToAlpha :: SomeColor -> AlphaColour Double
 someToAlpha (SomeColor c) = toAlphaColour c
 
-instance (Floating a, Real a) => Color (Colour a) where
-  toAlphaColour   = opaque . colourConvert
-  fromAlphaColour = colourConvert . (`over` black)
+instance a ~ Double => Color (Colour a) where
+  toAlphaColour   = opaque
+  fromAlphaColour = (`over` black)
 
-instance (Floating a, Real a) => Color (AlphaColour a) where
-  toAlphaColour   = alphaColourConvert
-  fromAlphaColour = alphaColourConvert
+instance a ~ Double => Color (AlphaColour a) where
+  toAlphaColour   = id
+  fromAlphaColour = id
 
 instance Color SomeColor where
   toAlphaColour (SomeColor c) = toAlphaColour c
@@ -284,7 +284,7 @@ colorToSRGBA col = (r, g, b, a)
 colorToRGBA = colorToSRGBA
 {-# DEPRECATED colorToRGBA "Renamed to colorToSRGBA." #-}
 
-alphaToColour :: (Floating a, Ord a, Fractional a) => AlphaColour a -> Colour a
+alphaToColour :: (Floating a, Ord a) => AlphaColour a -> Colour a
 alphaToColour ac | alphaChannel ac == 0 = ac `over` black
                  | otherwise = darken (recip (alphaChannel ac)) (ac `over` black)
 

--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -43,6 +43,7 @@ module Diagrams.BoundingBox
   , union, intersection
   ) where
 
+import           Control.Lens            (AsEmpty (..), nearly)
 import           Data.Foldable           as F
 import           Data.Maybe              (fromMaybe)
 import           Data.Semigroup
@@ -93,6 +94,9 @@ newtype BoundingBox v n = BoundingBox (Option (NonEmptyBoundingBox v n))
 
 deriving instance (Additive v, Ord n) => Semigroup (BoundingBox v n)
 deriving instance (Additive v, Ord n) => Monoid (BoundingBox v n)
+
+instance AsEmpty (BoundingBox v n) where
+  _Empty = nearly emptyBox isEmptyBox
 
 type instance V (BoundingBox v n) = v
 type instance N (BoundingBox v n) = n

--- a/src/Diagrams/Deform.hs
+++ b/src/Diagrams/Deform.hs
@@ -32,7 +32,7 @@ import           Linear.Vector
 
 -- | @Deformations@ are a superset of the affine transformations
 --   represented by the 'Transformation' type.  In general they are not
---   invertable.  @Deformation@s include projective transformations.
+--   invertible.  @Deformation@s include projective transformations.
 --   @Deformation@ can represent other functions from points to points
 --   which are "well-behaved", in that they do not introduce small wiggles.
 newtype Deformation v u n = Deformation (Point v n -> Point u n)

--- a/src/Diagrams/LinearMap.hs
+++ b/src/Diagrams/LinearMap.hs
@@ -91,7 +91,7 @@ instance (Metric v, Metric u, OrderedField n, OrderedField m, r ~ Trail u m)
   {-# INLINE vmap #-}
 
 instance LinearMappable (Point v n) (Point u m) where
-  vmap f (P v) = P  (f v)
+  vmap f (P v) = P (f v)
   {-# INLINE vmap #-}
 
 instance r ~ FixedSegment u m => LinearMappable (FixedSegment v n) r where

--- a/src/Diagrams/LinearMap.hs
+++ b/src/Diagrams/LinearMap.hs
@@ -24,7 +24,7 @@ module Diagrams.LinearMap where
 
 import           Control.Lens
 import           Data.FingerTree         as FT
-import qualified Data.Foldable as F
+import qualified Data.Foldable           as F
 
 import           Diagrams.Core
 import           Diagrams.Core.Transform
@@ -109,8 +109,8 @@ instance (Metric v, Metric u, OrderedField n, OrderedField m, r ~ Path u m)
   vmap f = _Wrapped . mapped %~ vmap f
   {-# INLINE vmap #-}
 
--- | Affine linear maps. Unlike Transformation these do not have to be
---   invertable so we can map between spaces.
+-- | Affine linear maps. Unlike 'Transformation' these do not have to be
+--   invertible so we can map between spaces.
 data AffineMap v u n = AffineMap (LinearMap v u n) (u n)
 
 -- | Make an affine map from a linear function and a translation.

--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -25,6 +25,7 @@ module Diagrams.Located
 
 import           Control.Lens            (Lens, Lens')
 import           Data.Functor            ((<$>))
+import           Text.Read
 
 import           Linear.Affine
 import           Linear.Vector
@@ -86,7 +87,7 @@ mapLoc :: SameSpace a b => (a -> b) -> Located a -> Located b
 mapLoc f (Loc p a) = Loc p (f a)
 
 -- | A lens giving access to the object within a 'Located' wrapper.
-located ::SameSpace a b => Lens (Located a) (Located b) a b
+located :: SameSpace a b => Lens (Located a) (Located b) a b
 located f (Loc p a) = Loc p <$> f a
 
 -- | Lens onto the location of something 'Located'.
@@ -96,7 +97,20 @@ _loc f (Loc p a) = flip Loc a <$> f p
 
 deriving instance (Eq   (V a (N a)), Eq a  ) => Eq   (Located a)
 deriving instance (Ord  (V a (N a)), Ord a ) => Ord  (Located a)
-deriving instance (Show (V a (N a)), Show a) => Show (Located a)
+-- deriving instance (Show (V a (N a)), Show a) => Show (Located a)
+
+instance (Show (V a (N a)), Show a) => Show (Located a) where
+  showsPrec d (Loc p a) = showParen (d > 5) $
+    showsPrec 6 a . showString " `at` " . showsPrec 6 p
+
+instance (Read (V a (N a)), Read a) => Read (Located a) where
+  readPrec = parens . prec 5 $ do
+    a <- readPrec
+    Punc "`"   <- lexP
+    Ident "at" <- lexP
+    Punc "`"   <- lexP
+    p <- readPrec
+    return (Loc p a)
 
 type instance V (Located a) = V a
 type instance N (Located a) = N a

--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -5,7 +5,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Located
--- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2013-2015 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -19,21 +19,19 @@
 
 module Diagrams.Located
     ( Located (..)
-    , at, viewLoc, mapLoc, located,
+    , at, viewLoc, mapLoc, located, _loc
     )
     where
 
-import           Control.Lens            (Lens)
+import           Control.Lens            (Lens, Lens')
 import           Data.Functor            ((<$>))
 
 import           Linear.Affine
 import           Linear.Vector
 
 import           Diagrams.Core
-import           Diagrams.Core.Points    ()
 import           Diagrams.Core.Transform
 import           Diagrams.Parametric
-  -- for GHC 7.4 type family bug
 
 -- | \"Located\" things, /i.e./ things with a concrete location:
 --   intuitively, @Located a ~ (Point, a)@.  Wrapping a translationally
@@ -84,12 +82,17 @@ viewLoc (Loc p a) = (p,a)
 --   @Located@ is a little-f (endo)functor on the category of types
 --   with associated vector space @v@; but that is not covered by the
 --   standard @Functor@ class.)
-mapLoc :: (V a ~ V b, N a ~ N b) => (a -> b) -> Located a -> Located b
+mapLoc :: SameSpace a b => (a -> b) -> Located a -> Located b
 mapLoc f (Loc p a) = Loc p (f a)
 
 -- | A lens giving access to the object within a 'Located' wrapper.
-located :: (V a ~ V a', N a ~ N a') => Lens (Located a) (Located a') a a'
+located ::SameSpace a b => Lens (Located a) (Located b) a b
 located f (Loc p a) = Loc p <$> f a
+
+-- | Lens onto the location of something 'Located'.
+_loc :: Lens' (Located a) (Point (V a) (N a))
+_loc f (Loc p a) = flip Loc a <$> f p
+
 
 deriving instance (Eq   (V a (N a)), Eq a  ) => Eq   (Located a)
 deriving instance (Ord  (V a (N a)), Ord a ) => Ord  (Located a)

--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -94,10 +94,8 @@ located f (Loc p a) = Loc p <$> f a
 _loc :: Lens' (Located a) (Point (V a) (N a))
 _loc f (Loc p a) = flip Loc a <$> f p
 
-
 deriving instance (Eq   (V a (N a)), Eq a  ) => Eq   (Located a)
 deriving instance (Ord  (V a (N a)), Ord a ) => Ord  (Located a)
--- deriving instance (Show (V a (N a)), Show a) => Show (Located a)
 
 instance (Show (V a (N a)), Show a) => Show (Located a) where
   showsPrec d (Loc p a) = showParen (d > 5) $
@@ -143,7 +141,7 @@ instance (Traced a, Num (N a)) => Traced (Located a) where
   getTrace (Loc p a) = moveTo p (getTrace a)
 
 instance Qualifiable a => Qualifiable (Located a) where
-  n >| (Loc p a) = Loc p (n >| a)
+  n .>> (Loc p a) = Loc p (n .>> a)
 
 type instance Codomain (Located a) = Point (Codomain a)
 

--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -143,7 +143,7 @@ instance (Traced a, Num (N a)) => Traced (Located a) where
   getTrace (Loc p a) = moveTo p (getTrace a)
 
 instance Qualifiable a => Qualifiable (Located a) where
-  n |> (Loc p a) = Loc p (n |> a)
+  n >| (Loc p a) = Loc p (n >| a)
 
 type instance Codomain (Located a) = Point (Codomain a)
 

--- a/src/Diagrams/Path.hs
+++ b/src/Diagrams/Path.hs
@@ -113,7 +113,10 @@ instance Wrapped (Path v n) where
 instance Rewrapped (Path v n) (Path v' n')
 
 instance Each (Path v n) (Path v' n') (Located (Trail v n)) (Located (Trail v' n')) where
-  each = _Wrapped . traversed
+  each = _Wrapped . traverse
+
+instance AsEmpty (Path v n) where
+  _Empty = _Wrapped' . _Empty
 
 -- | Extract the located trails making up a 'Path'.
 pathTrails :: Path v n -> [Located (Trail v n)]

--- a/src/Diagrams/Path.hs
+++ b/src/Diagrams/Path.hs
@@ -61,8 +61,7 @@ module Diagrams.Path
        ) where
 
 import           Control.Arrow        ((***))
-import           Control.Lens         (Rewrapped, Wrapped (..), iso, mapped, op, over, view, (%~),
-                                       _Unwrapped', _Wrapped, Each (..), traversed)
+import           Control.Lens         hiding ((#), transform, at)
 import qualified Data.Foldable        as F
 import           Data.List            (partition)
 import           Data.Semigroup
@@ -77,7 +76,6 @@ import           Diagrams.Trail
 import           Diagrams.TrailLike
 import           Diagrams.Transform
 
-import           Linear.Affine
 import           Linear.Metric
 import           Linear.Vector
 
@@ -261,7 +259,7 @@ partitionPath p = (view _Unwrapped' *** view _Unwrapped') . partition p . op Pat
 -- | Scale a path using its centroid (see 'pathCentroid') as the base
 --   point for the scale.
 scalePath :: (HasLinearMap v, Metric v, OrderedField n) => n -> Path v n -> Path v n
-scalePath d p = (scale d `under` translation (origin .-. pathCentroid p)) p
+scalePath d p = under (movedFrom (pathCentroid p)) (scale d) p
 
 -- | Reverse all the component trails of a path.
 reversePath :: (Metric v, OrderedField n) => Path v n -> Path v n

--- a/src/Diagrams/Path.hs
+++ b/src/Diagrams/Path.hs
@@ -268,5 +268,6 @@ scalePath d p = under (movedFrom (pathCentroid p)) (scale d) p
 reversePath :: (Metric v, OrderedField n) => Path v n -> Path v n
 reversePath = _Wrapped . mapped %~ reverseLocTrail
 
+-- | Same as 'reversePath'.
 instance (Metric v, OrderedField n) => Reversing (Path v n) where
   reversing = _Wrapped' . mapped %~ reversing

--- a/src/Diagrams/Path.hs
+++ b/src/Diagrams/Path.hs
@@ -265,3 +265,5 @@ scalePath d p = under (movedFrom (pathCentroid p)) (scale d) p
 reversePath :: (Metric v, OrderedField n) => Path v n -> Path v n
 reversePath = _Wrapped . mapped %~ reverseLocTrail
 
+instance (Metric v, OrderedField n) => Reversing (Path v n) where
+  reversing = _Wrapped' . mapped %~ reversing

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -19,6 +19,10 @@ module Diagrams.Prelude
 
     -- * Convenience re-exports
 
+    -- | For working with default values. Diagrams also exports 'with',
+    --   an alias for 'def'.
+  , module Data.Default.Class
+
     -- | For representing and operating on colors.
   , module Data.Colour
 
@@ -80,6 +84,7 @@ import           Control.Lens               hiding (argument, at, backwards,
                                              none, outside, singular, transform,
                                              ( # ), (...), (.>), (<.>))
 import           Data.Active
+import           Data.Default.Class
 import           Data.Colour                hiding (AffineSpace (..), atop,
                                              over)
 import           Data.Colour.Names          hiding (tan)

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -12,174 +12,48 @@
 -----------------------------------------------------------------------------
 
 module Diagrams.Prelude
-       (
-         -- * Core library
-         -- | The core definitions of transformations, diagrams,
-         --   backends, and so on.
-         module Diagrams.Core
+  (
+    -- * Diagrams library
+    -- | Exports from this library for working with diagrams.
+    module Diagrams
 
-         -- * Standard library
+    -- * Convenience re-exports
 
-         -- | Attributes (color, line style, etc.) and styles.
-       , module Diagrams.Attributes
+    -- | For representing and operating on colors.
+  , module Data.Colour
 
-         -- | Alignment of diagrams relative to their envelopes.
-       , module Diagrams.Align
+    -- | A large list of color names.
+  , module Data.Colour.Names
 
-         -- | Creating and using bounding boxes.
-       , module Diagrams.BoundingBox
+    -- | Specify your own colours.
+  , module Data.Colour.SRGB
 
-         -- | Combining multiple diagrams into one.
-       , module Diagrams.Combinators
+    -- | Semigroups and monoids show up all over the place, so things from
+    --   Data.Semigroup and Data.Monoid often come in handy.
+  , module Data.Semigroup
 
-         -- | Giving concrete locations to translation-invariant things.
-       , module Diagrams.Located
+    -- | For computing with vectors.
+  , module Linear.Vector
 
-         -- | Linear and cubic bezier segments.
-       , module Diagrams.Segment
+    -- | For computing with points and vectors.
+  , module Linear.Affine
 
-         -- | Trails.
-       , module Diagrams.Trail
+    -- | For computing with dot products and norm.
+  , module Linear.Metric
 
-         -- | Parametrization of segments and trails.
-       , module Diagrams.Parametric
+    -- | For working with 'Active' (i.e. animated) things.
+  , module Data.Active
 
-         -- | Adjusting the length of parameterized objects.
-       , module Diagrams.Parametric.Adjust
+    -- | This exports most of the lens module, excluding the
+    --   following functions that can cause collisions with diagrams:
+    -- @contains@, @inside@, @outside@, @none@, @transform@, @(#)@
+    -- (replaced by @##@) and @.>@ (which is just '.' anyway).
+  , module Control.Lens
 
-         -- | Computing tangent and normal vectors of segments and
-         --   trails.
-       , module Diagrams.Tangent
+  , Applicative(..), (*>), (<*), (<$>), (<$), liftA, liftA2, liftA3
+  ) where
 
-         -- | Trail-like things.
-       , module Diagrams.TrailLike
-
-         -- | Paths.
-       , module Diagrams.Path
-
-         -- | Cubic splines.
-       , module Diagrams.CubicSpline
-
-         -- | Some additional transformation-related functions, like
-         --   conjugation of transformations.
-       , module Diagrams.Transform
-
-         -- | Projective transformations and other deformations
-         -- lacking an inverse.
-       , module Diagrams.Deform
-
-         -- | Giving names to subdiagrams and later retrieving
-         --   subdiagrams by name.
-       , module Diagrams.Names
-
-         -- | Envelopes, aka functional bounding regions.
-       , module Diagrams.Envelope
-
-         -- | Traces, aka embedded raytracers, for finding points on
-         --   the boundary of a diagram.
-       , module Diagrams.Trace
-
-         -- | A query is a function that maps points in a vector space
-         --   to values in some monoid; they can be used to annotate
-         --   the points of a diagram with some values.
-       , module Diagrams.Query
-
-         -- | Utilities for working with points.
-       , module Diagrams.Points
-
-         -- | Utilities for working with size.
-       , module Diagrams.Size
-
-         -- | Angles
-       , module Diagrams.Angle
-
-         -- | Convenience infix operators for working with coordinates.
-       , module Diagrams.Coordinates
-
-         -- | Directions, distinguished from angles or vectors
-       , module Diagrams.Direction
-
-         -- | A wide range of things (shapes, transformations,
-         --   combinators) specific to creating two-dimensional
-         --   diagrams.
-       , module Diagrams.TwoD
-
-         -- | Extra things for three-dimensional diagrams.
-       , module Diagrams.ThreeD
-
-         -- | Tools for making animations.
-       , module Diagrams.Animation
-
-         -- | Various utility definitions.
-       , module Diagrams.Util
-
-         -- * Convenience re-exports
-
-         -- | For representing and operating on colors.
-       , module Data.Colour
-
-         -- | A large list of color names.
-       , module Data.Colour.Names
-
-         -- | Specify your own colours.
-       , module Data.Colour.SRGB
-
-         -- | Semigroups and monoids show up all over the place, so things from
-         --   Data.Semigroup and Data.Monoid often come in handy.
-       , module Data.Semigroup
-
-         -- | For computing with vectors.
-       , module Linear.Vector
-
-         -- | For computing with points and vectors.
-       , module Linear.Affine
-
-         -- | For computing with dot products and norm.
-       , module Linear.Metric
-
-         -- | For working with 'Active' (i.e. animated) things.
-       , module Data.Active
-
-         -- | This exports most of the lens module, excluding the
-         --   following functions that can cause collisions with diagrams:
-         -- @contains@, @inside@, @outside@, @none@, @transform@, @(#)@
-         -- (replaced by @##@) and @.>@ (which is just '.' anyway).
-       , module Control.Lens
-
-       , Applicative(..), (*>), (<*), (<$>), (<$), liftA, liftA2, liftA3
-       ) where
-
-import           Diagrams.Core
-
-import           Diagrams.Align
-import           Diagrams.Angle
-import           Diagrams.Animation
-import           Diagrams.Attributes
-import           Diagrams.BoundingBox       hiding (intersection, union, inside, outside, contains)
-import           Diagrams.Combinators
-import           Diagrams.Coordinates
-import           Diagrams.CubicSpline
-import           Diagrams.Deform
-import           Diagrams.Direction         hiding (dir)
-import           Diagrams.Envelope
-import           Diagrams.Located
-import           Diagrams.Names
-import           Diagrams.Parametric
-import           Diagrams.Parametric.Adjust
-import           Diagrams.Path
-import           Diagrams.Points
-import           Diagrams.Query
-import           Diagrams.Segment
-import           Diagrams.Size
-import           Diagrams.Tangent
-import           Diagrams.ThreeD
-import           Diagrams.Trace
-import           Diagrams.Trail             hiding (linePoints, loopPoints,
-                                             trailPoints)
-import           Diagrams.TrailLike
-import           Diagrams.Transform
-import           Diagrams.TwoD
-import           Diagrams.Util
+import           Diagrams
 
 import           Control.Applicative
 import           Control.Lens               hiding (at, backwards, beside,

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -26,6 +26,9 @@ module Diagrams.Prelude
          -- | Alignment of diagrams relative to their envelopes.
        , module Diagrams.Align
 
+         -- | Creating and using bounding boxes.
+       , module Diagrams.BoundingBox
+
          -- | Combining multiple diagrams into one.
        , module Diagrams.Combinators
 
@@ -144,6 +147,7 @@ import           Diagrams.Align
 import           Diagrams.Angle
 import           Diagrams.Animation
 import           Diagrams.Attributes
+import           Diagrams.BoundingBox       hiding (intersection, union)
 import           Diagrams.Combinators
 import           Diagrams.Coordinates
 import           Diagrams.CubicSpline

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -44,10 +44,28 @@ module Diagrams.Prelude
     -- | For working with 'Active' (i.e. animated) things.
   , module Data.Active
 
-    -- | This exports most of the lens module, excluding the
-    --   following functions that can cause collisions with diagrams:
-    -- @contains@, @inside@, @outside@, @none@, @transform@, @(#)@
-    -- (replaced by @##@) and @.>@ (which is just '.' anyway).
+    -- | Most of the lens package. The following functions are not
+    --   exported from lens because they either conflict with
+    --   diagrams or may conflict with other libraries:
+    --
+    --   * 'Control.Lens....'
+    --   * 'Control.Lens..>'
+    --   * 'Control.Lens.<.>'
+    --   * 'Control.Lens.argument'
+    --   * 'Control.Lens.at'
+    --   * 'Control.Lens.beside'
+    --   * 'Control.Lens.children'
+    --   * 'Control.Lens.coerce'
+    --   * 'Control.Lens.contains'
+    --   * 'Control.Lens.index'
+    --   * 'Control.Lens.indexed'
+    --   * 'Control.Lens.indices'
+    --   * 'Control.Lens.inside'
+    --   * 'Control.Lens.levels'
+    --   * 'Control.Lens.none'
+    --   * 'Control.Lens.outside'
+    --   * 'Control.Lens.singular'
+    --   * 'Control.Lens.transform'
   , module Control.Lens
 
   , Applicative(..), (*>), (<*), (<$>), (<$), liftA, liftA2, liftA3
@@ -56,13 +74,16 @@ module Diagrams.Prelude
 import           Diagrams
 
 import           Control.Applicative
-import           Control.Lens               hiding (at, backwards, beside,
-                                             contains, inside, none, outside,
-                                             transform, ( # ), (.>))
+import           Control.Lens               hiding (argument, at, backwards,
+                                             beside, children, coerce, contains,
+                                             indexed, indices, inside, levels,
+                                             none, outside, singular, transform,
+                                             ( # ), (...), (.>), (<.>))
 import           Data.Active
-import           Data.Colour                hiding (AffineSpace (..), atop, over)
-import           Data.Colour.SRGB
+import           Data.Colour                hiding (AffineSpace (..), atop,
+                                             over)
 import           Data.Colour.Names          hiding (tan)
+import           Data.Colour.SRGB
 import           Data.Semigroup
 
 import           Linear.Affine

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -119,6 +119,10 @@ module Diagrams.Prelude
 
          -- | A large list of color names.
        , module Data.Colour.Names
+
+         -- | Specify your own colours.
+       , module Data.Colour.SRGB
+
          -- | Semigroups and monoids show up all over the place, so things from
          --   Data.Semigroup and Data.Monoid often come in handy.
        , module Data.Semigroup
@@ -175,7 +179,13 @@ import           Diagrams.Util
 import           Control.Applicative
 import           Control.Lens               ((%~), (&), (.~))
 import           Data.Active
+<<<<<<< HEAD
 import           Data.Colour                hiding (AffineSpace (..), atop, over)
+=======
+import           Data.Colour                hiding (AffineSpace (..), atop,
+                                             over)
+import           Data.Colour.SRGB
+>>>>>>> 8bd62e5... SomeColor Show instance.
 import           Data.Colour.Names          hiding (tan)
 import           Data.Semigroup
 

--- a/src/Diagrams/Prelude.hs
+++ b/src/Diagrams/Prelude.hs
@@ -2,7 +2,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Prelude
--- Copyright   :  (c) 2011 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2011-2015 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -114,6 +114,7 @@ module Diagrams.Prelude
        , module Diagrams.Util
 
          -- * Convenience re-exports
+
          -- | For representing and operating on colors.
        , module Data.Colour
 
@@ -139,8 +140,11 @@ module Diagrams.Prelude
          -- | For working with 'Active' (i.e. animated) things.
        , module Data.Active
 
-         -- | Essential Lens Combinators
-       , (&), (.~), (%~)
+         -- | This exports most of the lens module, excluding the
+         --   following functions that can cause collisions with diagrams:
+         -- @contains@, @inside@, @outside@, @none@, @transform@, @(#)@
+         -- (replaced by @##@) and @.>@ (which is just '.' anyway).
+       , module Control.Lens
 
        , Applicative(..), (*>), (<*), (<$>), (<$), liftA, liftA2, liftA3
        ) where
@@ -151,7 +155,7 @@ import           Diagrams.Align
 import           Diagrams.Angle
 import           Diagrams.Animation
 import           Diagrams.Attributes
-import           Diagrams.BoundingBox       hiding (intersection, union)
+import           Diagrams.BoundingBox       hiding (intersection, union, inside, outside, contains)
 import           Diagrams.Combinators
 import           Diagrams.Coordinates
 import           Diagrams.CubicSpline
@@ -170,22 +174,20 @@ import           Diagrams.Size
 import           Diagrams.Tangent
 import           Diagrams.ThreeD
 import           Diagrams.Trace
-import           Diagrams.Trail             hiding (linePoints, loopPoints, trailPoints)
+import           Diagrams.Trail             hiding (linePoints, loopPoints,
+                                             trailPoints)
 import           Diagrams.TrailLike
 import           Diagrams.Transform
 import           Diagrams.TwoD
 import           Diagrams.Util
 
 import           Control.Applicative
-import           Control.Lens               ((%~), (&), (.~))
+import           Control.Lens               hiding (at, backwards, beside,
+                                             contains, inside, none, outside,
+                                             transform, ( # ), (.>))
 import           Data.Active
-<<<<<<< HEAD
 import           Data.Colour                hiding (AffineSpace (..), atop, over)
-=======
-import           Data.Colour                hiding (AffineSpace (..), atop,
-                                             over)
 import           Data.Colour.SRGB
->>>>>>> 8bd62e5... SomeColor Show instance.
 import           Data.Colour.Names          hiding (tan)
 import           Data.Semigroup
 

--- a/src/Diagrams/Segment.hs
+++ b/src/Diagrams/Segment.hs
@@ -64,8 +64,7 @@ module Diagrams.Segment
 
        ) where
 
-import           Control.Lens              (Each (..), Rewrapped, Wrapped (..),
-                                            iso, makeLenses, op, over)
+import           Control.Lens              hiding (at, transform)
 import           Data.FingerTree
 import           Data.Monoid.MList
 import           Data.Semigroup
@@ -122,6 +121,10 @@ instance Each (Offset c v n) (Offset c v' n') (v n) (v' n') where
   each _ OffsetOpen       = pure OffsetOpen
   {-# INLINE each #-}
 
+instance (Additive v, Num n) => Reversing (Offset c v n) where
+  reversing (OffsetClosed off) = OffsetClosed $ negated off
+  reversing a@OffsetOpen       = a
+
 type instance V (Offset c v n) = v
 type instance N (Offset c v n) = n
 
@@ -171,6 +174,9 @@ instance Each (Segment c v n) (Segment c v' n') (v n) (v' n') where
   each f (Linear offset)      = Linear <$> each f offset
   each f (Cubic v1 v2 offset) = Cubic  <$> f v1 <*> f v2 <*> each f offset
   {-# INLINE each #-}
+
+instance (Additive v, Num n) => Reversing (Segment Closed v n) where
+  reversing = reverseSegment
 
 -- | Map over the vectors of each segment.
 mapSegmentVectors :: (v n -> v' n') -> Segment c v n -> Segment c v' n'
@@ -314,7 +320,7 @@ reverseSegment :: (Num n, Additive v) => Segment Closed v n -> Segment Closed v 
 reverseSegment (Linear (OffsetClosed v))       = straight (negated v)
 reverseSegment (Cubic c1 c2 (OffsetClosed x2)) = bezier3 (c2 ^-^ x2) (c1 ^-^ x2) (negated x2)
 
-instance (Metric v, Floating n, Ord n, Additive v)
+instance (Metric v, OrderedField n)
       => HasArcLength (Segment Closed v n) where
 
   arcLengthBounded _ (Linear (OffsetClosed x1)) = I.singleton $ norm x1
@@ -363,6 +369,10 @@ instance Each (FixedSegment v n) (FixedSegment v' n') (Point v n) (Point v' n') 
   each f (FLinear p0 p1)      = FLinear <$> f p0 <*> f p1
   each f (FCubic p0 p1 p2 p3) = FCubic  <$> f p0 <*> f p1 <*> f p2 <*> f p3
   {-# INLINE each #-}
+
+instance Reversing (FixedSegment v n) where
+  reversing (FLinear p0 p1)      = FLinear p1 p0
+  reversing (FCubic p0 p1 p2 p3) = FCubic p3 p2 p1 p0
 
 instance (Additive v, Num n) => Transformable (FixedSegment v n) where
   transform t = over each (papply t)

--- a/src/Diagrams/Segment.hs
+++ b/src/Diagrams/Segment.hs
@@ -121,6 +121,7 @@ instance Each (Offset c v n) (Offset c v' n') (v n) (v' n') where
   each _ OffsetOpen       = pure OffsetOpen
   {-# INLINE each #-}
 
+-- | Reverses the direction of closed offsets.
 instance (Additive v, Num n) => Reversing (Offset c v n) where
   reversing (OffsetClosed off) = OffsetClosed $ negated off
   reversing a@OffsetOpen       = a
@@ -175,6 +176,7 @@ instance Each (Segment c v n) (Segment c v' n') (v n) (v' n') where
   each f (Cubic v1 v2 offset) = Cubic  <$> f v1 <*> f v2 <*> each f offset
   {-# INLINE each #-}
 
+-- | Reverse the direction of a segment.
 instance (Additive v, Num n) => Reversing (Segment Closed v n) where
   reversing = reverseSegment
 
@@ -370,6 +372,7 @@ instance Each (FixedSegment v n) (FixedSegment v' n') (Point v n) (Point v' n') 
   each f (FCubic p0 p1 p2 p3) = FCubic  <$> f p0 <*> f p1 <*> f p2 <*> f p3
   {-# INLINE each #-}
 
+-- | Reverses the control points.
 instance Reversing (FixedSegment v n) where
   reversing (FLinear p0 p1)      = FLinear p1 p0
   reversing (FCubic p0 p1 p2 p3) = FCubic p3 p2 p1 p0

--- a/src/Diagrams/Size.hs
+++ b/src/Diagrams/Size.hs
@@ -91,7 +91,8 @@ getSpec :: (Functor v, Num n, Ord n) => SizeSpec v n -> v (Maybe n)
 getSpec (SizeSpec sp) = mfilter (>0) . Just <$> sp
 
 -- | Make a 'SizeSpec' from a vector of maybe values. Any negative values will
---   be ignored.
+--   be ignored. For 2D 'SizeSpec's see 'mkWidth' and 'mkHeight' from
+--   "Diagrams.TwoD.Size".
 mkSizeSpec :: (Functor v, Num n) => v (Maybe n) -> SizeSpec v n
 mkSizeSpec = dims . fmap (fromMaybe 0)
 
@@ -146,7 +147,7 @@ sizedAs :: (InSpace v n a, SameSpace a b, HasLinearMap v, HasBasis v, Transforma
 sizedAs other = sized (dims $ size other)
 
 -- | Get the adjustment to fit a 'BoundingBox' in the given 'SizeSpec'. The
---   vector is the new size and the transformation  to position the lower
+--   vector is the new size and the transformation to position the lower
 --   corner at the origin and scale to the size spec.
 sizeAdjustment :: (Additive v, Foldable v, OrderedField n)
   => SizeSpec v n -> BoundingBox v n -> (v n, Transformation v n)

--- a/src/Diagrams/Tangent.hs
+++ b/src/Diagrams/Tangent.hs
@@ -75,15 +75,15 @@ instance (DomainBounds t, EndValues (Tangent t))
 --   * @Located (Trail V2) -> Double -> V2 Double@
 --
 --   See the instances listed for the 'Tangent' newtype for more.
-tangentAtParam :: Parametric (Tangent t) => t -> N t -> Codomain (Tangent t) (N t)
+tangentAtParam :: Parametric (Tangent t) => t -> N t -> Vn t
 tangentAtParam t p = Tangent t `atParam` p
 
 -- | Compute the tangent vector at the start of a segment or trail.
-tangentAtStart :: EndValues (Tangent t) => t -> Codomain (Tangent t) (N t)
+tangentAtStart :: EndValues (Tangent t) => t -> Vn t
 tangentAtStart = atStart . Tangent
 
 -- | Compute the tangent vector at the end of a segment or trail.
-tangentAtEnd :: EndValues (Tangent t) => t -> Codomain (Tangent t) (N t)
+tangentAtEnd :: EndValues (Tangent t) => t -> Vn t
 tangentAtEnd = atEnd . Tangent
 
 --------------------------------------------------
@@ -102,6 +102,15 @@ instance (Additive v, Num n)
   atEnd   (Tangent (Linear (OffsetClosed v)))      = v
   atEnd   (Tangent (Cubic _ c2 (OffsetClosed x2))) = x2 ^-^ c2
 
+instance (Additive v, Num n)
+    => Parametric (Tangent (FixedSegment v n)) where
+  atParam (Tangent fSeg) = atParam $ Tangent (fromFixedSeg fSeg)
+
+instance (Additive v, Num n)
+    => EndValues (Tangent (FixedSegment v n)) where
+  atStart (Tangent fSeg) = atStart $ Tangent (fromFixedSeg fSeg)
+  atEnd (Tangent fSeg)   = atEnd $ Tangent (fromFixedSeg fSeg)
+
 ------------------------------------------------------------
 -- Normal
 ------------------------------------------------------------
@@ -119,20 +128,20 @@ instance (Additive v, Num n)
 --
 --   See the instances listed for the 'Tangent' newtype for more.
 normalAtParam
-  :: (Codomain (Tangent t) ~ V2, Parametric (Tangent t), Floating (N t))
-  => t -> N t -> Codomain (Tangent t) (N t)
+  :: (InSpace V2 n t, Parametric (Tangent t), Floating n)
+  => t -> n -> V2 n
 normalAtParam t p = normize (t `tangentAtParam` p)
 
 -- | Compute the normal vector at the start of a segment or trail.
 normalAtStart
-  :: (Codomain (Tangent t) ~ V2, EndValues (Tangent t), Floating (N t))
-  => t -> Codomain (Tangent t) (N t)
+  :: (InSpace V2 n t, EndValues (Tangent t), Floating n)
+  => t -> V2 n
 normalAtStart = normize . tangentAtStart
 
 -- | Compute the normal vector at the end of a segment or trail.
 normalAtEnd
-  :: (Codomain (Tangent t) ~ V2, EndValues (Tangent t), Floating (N t))
-  => t -> Codomain (Tangent t) (N t)
+  :: (InSpace V2 n t, EndValues (Tangent t), Floating n)
+  => t -> V2 n
 normalAtEnd = normize . tangentAtEnd
 
 -- | Construct a normal vector from a tangent.

--- a/src/Diagrams/ThreeD/Transform.hs
+++ b/src/Diagrams/ThreeD/Transform.hs
@@ -22,8 +22,9 @@ module Diagrams.ThreeD.Transform
        ( T3
 
          -- * Rotation
-        ,aboutX, aboutY, aboutZ
-       , rotationAbout, pointAt, pointAt'
+       , aboutX, aboutY, aboutZ
+       , rotationAbout, rotateAbout
+       , pointAt, pointAt'
 
        -- * Scaling
        , scalingX, scalingY, scalingZ
@@ -105,7 +106,7 @@ aboutY (view rad -> a) = fromOrthogonal r where
 --   passing through @p@.
 rotationAbout
   :: Floating n
-	=> Point V3 n         -- ^ origin of rotation
+  => Point V3 n         -- ^ origin of rotation
   -> Direction V3 n     -- ^ direction of rotation axis
   -> Angle n            -- ^ angle of rotation
   -> Transformation V3 n
@@ -119,6 +120,16 @@ rotationAbout (P t) d (view rad -> a)
     rot θ v =          v ^* cos θ
            ^+^ cross w v ^* sin θ
            ^+^         w ^* ((w `dot` v) * (1 - cos θ))
+
+-- | @rotationAbout p d a@ is a rotation about a line parallel to @d@
+--   passing through @p@.
+rotateAbout
+  :: (InSpace V3 n t, Floating n, Transformable t)
+  => Point V3 n         -- ^ origin of rotation
+  -> Direction V3 n     -- ^ direction of rotation axis
+  -> Angle n            -- ^ angle of rotation
+  -> t -> t
+rotateAbout p d theta = transform (rotationAbout p d theta)
 
 -- | @pointAt about initial final@ produces a rotation which brings
 -- the direction @initial@ to point in the direction @final@ by first
@@ -187,8 +198,10 @@ reflectZ :: (InSpace v n t, R3 v, Transformable t) => t -> t
 reflectZ = transform reflectionZ
 
 -- | @reflectionAcross p v@ is a reflection across the plane through
---   the point @p@ and normal to vector @v@.
-reflectionAcross :: (Metric v, R3 v, Fractional n)
+--   the point @p@ and normal to vector @v@. This also works as a 2D
+--   transform where @v@ is the normal to the line passing through point
+--   @p@.
+reflectionAcross :: (Metric v, Fractional n)
   => Point v n -> v n -> Transformation v n
 reflectionAcross p v =
   conjugate (translation (origin .-. p)) reflect
@@ -198,8 +211,9 @@ reflectionAcross p v =
       f u w   = w ^-^ 2 *^ project u w
 
 -- | @reflectAcross p v@ reflects a diagram across the plane though
---   the point @p@ and the vector @v@.
-reflectAcross :: (InSpace v n t, Metric v, R3 v, Fractional n, Transformable t)
+--   the point @p@ and the vector @v@. This also works as a 2D transform
+--   where @v@ is the normal to the line passing through point @p@.
+reflectAcross :: (InSpace v n t, Metric v, Fractional n, Transformable t)
   => Point v n -> v n -> t -> t
 reflectAcross p v = transform (reflectionAcross p v)
 

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE LambdaCase                 #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -429,6 +430,9 @@ instance (Metric v, OrderedField n) => Monoid (Trail' Line v n) where
   mempty  = emptyLine
   mappend = (<>)
 
+instance (Metric v, OrderedField n) => AsEmpty (Trail' Line v n) where
+  _Empty = nearly emptyLine isLineEmpty
+
 instance (HasLinearMap v, Metric v, OrderedField n)
     => Transformable (Trail' l v n) where
   transform tr (Line t  ) = Line (transform tr t)
@@ -711,9 +715,12 @@ instance (OrderedField n, Metric v) => Semigroup (Trail v n) where
 --   strange.  Mostly it is provided for convenience, so one can work
 --   directly with @Trail@s instead of working with @Trail' Line@s and
 --   then wrapping.
-instance (OrderedField n, Metric v) => Monoid (Trail v n) where
+instance (Metric v, OrderedField n) => Monoid (Trail v n) where
   mempty  = wrapLine emptyLine
   mappend = (<>)
+
+instance (Metric v, OrderedField n) => AsEmpty (Trail v n) where
+  _Empty = nearly emptyTrail isTrailEmpty
 
 type instance V (Trail v n) = v
 type instance N (Trail v n) = n

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -1255,17 +1255,21 @@ reverseLocLoop :: (Metric v, OrderedField n)
                => Located (Trail' Loop v n) -> Located (Trail' Loop v n)
 reverseLocLoop = mapLoc reverseLoop
 
+-- | Same as 'reverseLine' or 'reverseLoop'.
 instance (Metric v, OrderedField n) => Reversing (Trail' l v n) where
   reversing t@(Line _)   = onLineSegments (reverse . map reversing) t
   reversing t@(Loop _ _) = glueLine . reversing . cutLoop $ t
 
+-- | Same as 'reverseTrail'.
 instance (Metric v, OrderedField n) => Reversing (Trail v n) where
   reversing (Trail t) = Trail (reversing t)
 
+-- | Same as 'reverseLocLine' or 'reverseLocLoop'.
 instance (Metric v, OrderedField n) => Reversing (Located (Trail' l v n)) where
   reversing l@(Loc _ Line {}) = reverseLocLine l
   reversing l@(Loc _ Loop {}) = reverseLocLoop l
 
+-- | Same as 'reverseLocTrail'.
 instance (Metric v, OrderedField n) => Reversing (Located (Trail v n)) where
   reversing = reverseLocTrail
 

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -1247,3 +1247,17 @@ reverseLocLoop :: (Metric v, OrderedField n)
                => Located (Trail' Loop v n) -> Located (Trail' Loop v n)
 reverseLocLoop = mapLoc reverseLoop
 
+instance (Metric v, OrderedField n) => Reversing (Trail' l v n) where
+  reversing t@(Line _)   = onLineSegments (reverse . map reversing) t
+  reversing t@(Loop _ _) = glueLine . reversing . cutLoop $ t
+
+instance (Metric v, OrderedField n) => Reversing (Trail v n) where
+  reversing (Trail t) = Trail (reversing t)
+
+instance (Metric v, OrderedField n) => Reversing (Located (Trail' l v n)) where
+  reversing l@(Loc _ Line {}) = reverseLocLine l
+  reversing l@(Loc _ Loop {}) = reverseLocLoop l
+
+instance (Metric v, OrderedField n) => Reversing (Located (Trail v n)) where
+  reversing = reverseLocTrail
+

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -115,7 +115,7 @@ import           Data.Monoid.MList
 import           Data.Semigroup
 import qualified Numeric.Interval.Kaucher as I
 
-import           Diagrams.Core            hiding ((|>))
+import           Diagrams.Core
 import           Diagrams.Located
 import           Diagrams.Parametric
 import           Diagrams.Segment

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -19,7 +19,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Trail
--- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2013-2015 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -856,7 +856,8 @@ lineFromSegments :: (Metric v, OrderedField n)
                    => [Segment Closed v n] -> Trail' Line v n
 lineFromSegments = Line . SegTree . FT.fromList
 
--- | @trailFromSegments === 'wrapTrail' . 'lineFromSegments'@, for
+-- | Contruct a loop from a list of close segments and an open segment
+--   that completes the loop.
 loopFromSegments :: (Metric v, OrderedField n)
                   => [Segment Closed v n] -> Segment Open v n -> Trail' Loop v n
 loopFromSegments segs = Loop (SegTree (FT.fromList segs))

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
@@ -10,7 +11,6 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE ViewPatterns               #-}
-{-# LANGUAGE LambdaCase                 #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -107,8 +107,9 @@ module Diagrams.Trail
        ) where
 
 import           Control.Arrow            ((***))
-import           Control.Lens             hiding ((|>), (<|), transform, at)
-import           Data.FingerTree          (FingerTree, ViewL (..), ViewR (..), (<|), (|>))
+import           Control.Lens             hiding (at, transform, (<|), (|>))
+import           Data.FingerTree          (FingerTree, ViewL (..), ViewR (..),
+                                           (<|), (|>))
 import qualified Data.FingerTree          as FT
 import           Data.Fixed
 import qualified Data.Foldable            as F
@@ -856,7 +857,7 @@ lineFromSegments :: (Metric v, OrderedField n)
                    => [Segment Closed v n] -> Trail' Line v n
 lineFromSegments = Line . SegTree . FT.fromList
 
--- | Contruct a loop from a list of close segments and an open segment
+-- | Construct a loop from a list of closed segments and an open segment
 --   that completes the loop.
 loopFromSegments :: (Metric v, OrderedField n)
                   => [Segment Closed v n] -> Segment Open v n -> Trail' Loop v n
@@ -1181,7 +1182,7 @@ loopVertices = loopVertices' tolerance
 -- The other points connecting segments are included if the slope at the
 -- end of a segment is not equal to the slope at the beginning of the next.
 -- The 'toler' parameter is used to control how close the slopes need to
--- be in order to declatre them equal.
+-- be in order to declare them equal.
 segmentVertices' :: (Metric v, OrderedField n)
              => n -> Point v n -> [Segment Closed v n] -> [Point v n]
 segmentVertices' toler p ts  =

--- a/src/Diagrams/Transform.hs
+++ b/src/Diagrams/Transform.hs
@@ -47,19 +47,22 @@ conjugate :: (Additive v, Num n, Functor v)
           => Transformation v n -> Transformation v n -> Transformation v n
 conjugate t1 t2 = inv t1 <> t2 <> t1
 
--- | Carry out some transformation \"under\" another one: @f ``under``
+-- | Carry out some transformation \"under\" another one: @f ``underT``
 --   t@ first applies @t@, then @f@, then the inverse of @t@.  For
---   example, @'scaleX' 2 ``under`` 'rotation' (-1/8 \@\@ Turn)@
+--   example, @'scaleX' 2 ``underT`` 'rotation' (-1/8 \@\@ Turn)@
 --   is the transformation which scales by a factor of 2 along the
 --   diagonal line y = x.
 --
 --   Note that
 --
 -- @
--- (transform t2) `under` t1 == transform (conjugate t1 t2)
+-- (transform t2) `underT` t1 == transform (conjugate t1 t2)
 -- @
 --
 --   for all transformations @t1@ and @t2@.
+--
+--   See also the isomorphisms like 'transformed', 'movedTo',
+--   'movedFrom', and 'translated'.
 underT :: (InSpace v n a, SameSpace a b, Transformable a, Transformable b)
       => (a -> b) -> Transformation v n -> a -> b
 f `underT` t = transform (inv t) . f . transform t

--- a/src/Diagrams/Transform.hs
+++ b/src/Diagrams/Transform.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE TypeFamilies          #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Transform
--- Copyright   :  (c) 2011-13 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2011-15 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -11,7 +14,6 @@
 --
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE TypeFamilies    #-}
 
 module Diagrams.Transform
     ( -- * Transformations
@@ -24,7 +26,7 @@ module Diagrams.Transform
     , translation, translate, moveTo, place, scaling, scale
 
       -- * Miscellaneous transformation-related utilities
-    , conjugate, under
+    , conjugate, underT, transformed, translated, movedTo, movedFrom
 
       -- * The HasOrigin class
 
@@ -32,6 +34,7 @@ module Diagrams.Transform
 
     ) where
 
+import           Control.Lens   hiding (transform)
 import           Data.Semigroup
 import           Diagrams.Core
 
@@ -42,7 +45,7 @@ import           Linear.Vector
 --   inverse of @t1@.
 conjugate :: (Additive v, Num n, Functor v)
           => Transformation v n -> Transformation v n -> Transformation v n
-conjugate t1 t2  = inv t1 <> t2 <> t1
+conjugate t1 t2 = inv t1 <> t2 <> t1
 
 -- | Carry out some transformation \"under\" another one: @f ``under``
 --   t@ first applies @t@, then @f@, then the inverse of @t@.  For
@@ -52,11 +55,66 @@ conjugate t1 t2  = inv t1 <> t2 <> t1
 --
 --   Note that
 --
---   @
---   (transform t2) `under` t1 == transform (conjugate t1 t2)
---   @
+-- @
+-- (transform t2) `under` t1 == transform (conjugate t1 t2)
+-- @
 --
 --   for all transformations @t1@ and @t2@.
-under :: (InSpace v n a, SameSpace a b, Num n, Functor v, Transformable a, Transformable b)
+underT :: (InSpace v n a, SameSpace a b, Transformable a, Transformable b)
       => (a -> b) -> Transformation v n -> a -> b
-f `under` t = transform (inv t) . f . transform t
+f `underT` t = transform (inv t) . f . transform t
+
+-- | Use a 'Transformation' to make an 'Iso' between an object
+--   transformed and untransformed. This is useful for carrying out
+--   functions 'under' another transform:
+--
+-- @
+-- under (transformed t) f               == transform (inv t) . f . transform t
+-- under (transformed t1) (transform t2) == transform (conjugate t1 t2)
+-- transformed t ## a                    == transform t a
+-- a ^. transformed t                    == transform (inv t) a
+-- @
+transformed :: (InSpace v n a, SameSpace a b, Transformable a, Transformable b)
+            => Transformation v n -> Iso a b a b
+transformed t = iso (transform $ inv t) (transform t)
+
+-- | Use a 'Point' to make an 'Iso' between an object
+--   moved to and from that point:
+--
+-- @
+-- under (movedTo p) f == moveTo (-p) . f . moveTo p
+-- over (movedTo p) f  == moveTo p . f . moveTo (-p)
+-- movedTo p           == from (movedFrom p)
+-- movedTo p ## a      == moveTo p a
+-- a ^. movedTo p      == moveOriginTo p a
+-- @
+movedTo :: (InSpace v n a, SameSpace a b, HasOrigin a, HasOrigin b)
+        => Point v n -> Iso a b a b
+movedTo p = iso (moveTo (negated p)) (moveTo p)
+
+-- | Use a 'Transformation' to make an 'Iso' between an object
+--   transformed and untransformed. We have
+--
+-- @
+-- under (movedFrom p) f == moveTo p . f . moveTo (-p)
+-- movedFrom p           == from (movedTo p)
+-- movedFrom p ## a      == moveOriginTo p a
+-- a ^. movedFrom p      == moveTo p a
+-- over (movedFrom p) f  == moveTo (-p) . f . moveTo p
+-- @
+movedFrom :: (InSpace v n a, SameSpace a b, HasOrigin a, HasOrigin b)
+          => Point v n -> Iso a b a b
+movedFrom p = iso (moveOriginTo (negated p)) (moveOriginTo p)
+
+-- | Use a vector to make an 'Iso' between an object translated and
+--   untranslated.
+--
+-- @
+-- under (translated v) f == translate (-v) . f . translate v
+-- translated v ## a      == translate v a
+-- a ^. translated v      == translate (-v) a
+-- over (translated v) f  == translate v . f . translate (-v)
+-- @
+translated :: (InSpace v n a, SameSpace a b, Transformable a, Transformable b)
+           => v n -> Iso a b a b
+translated = transformed . translation

--- a/src/Diagrams/Transform/Matrix.hs
+++ b/src/Diagrams/Transform/Matrix.hs
@@ -12,10 +12,10 @@
 module Diagrams.Transform.Matrix where
 
 import           Control.Applicative
-import           Control.Arrow ((&&&))
+import           Control.Arrow           ((&&&))
 import           Control.Lens
 import           Data.Distributive
-import qualified Data.Foldable as F
+import qualified Data.Foldable           as F
 import           Data.Functor.Rep
 
 import           Diagrams.Core.Transform as D
@@ -35,13 +35,13 @@ mkMatHomo :: Num n => Transformation V3 n -> M44 n
 mkMatHomo t = mkTransformationMat (mkMat t) (transl t)
 
 -- | Make a 2D transformation from a 2x2 transform matrix and a
---   translation vector. If the matrix is not invertable, 'Nothing' is
+--   translation vector. If the matrix is not invertible, 'Nothing' is
 --   returned.
 fromMat22 :: (Epsilon n, Floating n) => M22 n -> V2 n -> Maybe (T2 n)
 fromMat22 m v = flip (fromMatWithInv m) v <$> inv22 m
 
 -- | Make a 3D transformation from a 3x3 transform matrix and a
---   translation vector. If the matrix is not invertable, 'Nothing' is
+--   translation vector. If the matrix is not invertible, 'Nothing' is
 --   returned.
 fromMat33 :: (Epsilon n, Floating n) => M33 n -> V3 n -> Maybe (T3 n)
 fromMat33 m v = flip (fromMatWithInv m) v <$> inv33 m

--- a/src/Diagrams/Transform/Matrix.hs
+++ b/src/Diagrams/Transform/Matrix.hs
@@ -34,13 +34,20 @@ mkMat t = distribute . tabulate $ apply t . unit . el
 mkMatHomo :: Num n => Transformation V3 n -> M44 n
 mkMatHomo t = mkTransformationMat (mkMat t) (transl t)
 
+-- | Make a 2D transformation from a 2x2 transform matrix and a
+--   translation vector. If the matrix is not invertable, 'Nothing' is
+--   returned.
 fromMat22 :: (Epsilon n, Floating n) => M22 n -> V2 n -> Maybe (T2 n)
 fromMat22 m v = flip (fromMatWithInv m) v <$> inv22 m
 
+-- | Make a 3D transformation from a 3x3 transform matrix and a
+--   translation vector. If the matrix is not invertable, 'Nothing' is
+--   returned.
 fromMat33 :: (Epsilon n, Floating n) => M33 n -> V3 n -> Maybe (T3 n)
 fromMat33 m v = flip (fromMatWithInv m) v <$> inv33 m
 
--- | Build a transform with a maxtrix along with its inverse.
+-- | Build a transform with a maxtrix along with its inverse (this is
+--   not checked).
 fromMatWithInv :: (Additive v, Distributive v, Foldable v, Num n)
   => v (v n) -- ^ matrix
   -> v (v n) -- ^ inverse
@@ -51,10 +58,13 @@ fromMatWithInv m m_ v =
                  ((*! distribute m) <-> (*! distribute m_))
                  v
 
--- are these useful?
+-- | Prism onto a 2D transformation from a 2x2 transform matrix and
+--   translation vector.
 mat22 :: (Epsilon n, Floating n) => Prism' (M22 n, V2 n) (T2 n)
 mat22 = prism' (mkMat &&& transl) (uncurry fromMat22)
 
+-- | Prism onto a 2D transformation from a 2x2 transform matrix and
+--   translation vector.
 mat33 :: (Epsilon n, Floating n) => Prism' (M33 n, V3 n) (T3 n)
 mat33 = prism' (mkMat &&& transl) (uncurry fromMat33)
 

--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -70,6 +70,8 @@ module Diagrams.TwoD
 
          -- * Angles
        , tau
+       , angleV
+       , angleDir
 
          -- * Paths
          -- ** Stroking

--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -214,7 +214,7 @@ module Diagrams.TwoD
 
        , extrudeLeft, extrudeRight, extrudeBottom, extrudeTop
 
-       , view
+       , rectEnvelope
 
          -- ** Background
 

--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -256,7 +256,7 @@ module Diagrams.TwoD
        , rGradTrans, rGradSpreadMethod, defaultRG, _RG, mkRadialGradient
 
          -- ** Colors
-       , fillColor, _SC, fc, fcA, recommendFillColor
+       , fillColor, _SC, _AC, fc, fcA, recommendFillColor
        , lineColor, lc, lcA
 
          -- * Visual aids for understanding the internal model

--- a/src/Diagrams/TwoD.hs
+++ b/src/Diagrams/TwoD.hs
@@ -84,7 +84,7 @@ module Diagrams.TwoD
        , intersectPointsP, intersectPointsP'
 
          -- ** Clipping
-       , clipBy, clipTo, clipped
+       , clipBy, clipTo, clipped, _clip
 
          -- * Shapes
          -- ** Rules

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -220,8 +220,10 @@ tailLength :: Lens' (ArrowOpts n) (Measure n)
 
 -- | Set both the @headLength@ and @tailLength@ simultaneously.
 lengths :: Traversal' (ArrowOpts n) (Measure n)
-lengths f opts = (\h t -> opts & headLength .~ h & tailLength .~ t) <$> f (opts ^. headLength)
-             <*> f (opts ^. tailLength)
+lengths f opts =
+  (\h t -> opts & headLength .~ h & tailLength .~ t)
+    <$> f (opts ^. headLength)
+    <*> f (opts ^. tailLength)
 
 -- | A lens for setting or modifying the texture of an arrowhead. For
 --   example, one may write @... (with & headTexture .~ grad)@ to get an

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -275,9 +275,9 @@ colorJoint sStyle =
       o = fmap getOpacity . getAttr $ sStyle
   in
   case (c, o) of
-      (Nothing, Nothing) -> fillColor (black :: Colour Double) mempty
+      (Nothing, Nothing) -> fillColor black mempty
       (Just t, Nothing)  -> fillTexture t mempty
-      (Nothing, Just o') -> opacity o' . fillColor (black :: Colour Double) $ mempty
+      (Nothing, Just o') -> opacity o' . fillColor black $ mempty
       (Just t, Just o')  -> opacity o' . fillTexture t $ mempty
 
 -- | Get line width from a style.

--- a/src/Diagrams/TwoD/Attributes.hs
+++ b/src/Diagrams/TwoD/Attributes.hs
@@ -262,6 +262,12 @@ newtype LineTexture n = LineTexture (Last (Texture n))
   deriving (Typeable, Semigroup)
 instance (Typeable n) => AttributeClass (LineTexture n)
 
+instance Rewrapped (LineTexture n) (LineTexture n')
+instance Wrapped (LineTexture n) where
+  type Unwrapped (LineTexture n) = Texture n
+  _Wrapped' = iso getLineTexture mkLineTexture
+  {-# INLINE _Wrapped' #-}
+
 type instance V (LineTexture n) = V2
 type instance N (LineTexture n) = n
 
@@ -291,9 +297,6 @@ lineTextureA = applyTAttr
 
 _lineTexture :: (Floating n, Typeable n) => Lens' (Style V2 n) (Texture n)
 _lineTexture = atTAttr . anon def isDef . _LineTexture
-  where
-    isDef (LineTexture (Last (SC sc))) = toAlphaColour sc == opaque black
-    isDef _                            = False
 
 -- | Set the line (stroke) color.  This function is polymorphic in the
 --   color type (so it can be used with either 'Colour' or
@@ -329,6 +332,12 @@ lineRGradient g = lineTexture (RG g)
 --   is that of 'Recommed . Last'.
 newtype FillTexture n = FillTexture (Recommend (Last (Texture n)))
   deriving (Typeable, Semigroup)
+
+instance Rewrapped (FillTexture n) (FillTexture n')
+instance Wrapped (FillTexture n) where
+  type Unwrapped (FillTexture n) = Texture n
+  _Wrapped' = iso getFillTexture mkFillTexture
+  {-# INLINE _Wrapped' #-}
 
 instance Typeable n => AttributeClass (FillTexture n)
 

--- a/src/Diagrams/TwoD/Attributes.hs
+++ b/src/Diagrams/TwoD/Attributes.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -30,7 +31,7 @@
 
 module Diagrams.TwoD.Attributes (
   -- * Textures
-    Texture(..), solid, _SC, _LG, _RG, defaultLG, defaultRG
+    Texture(..), solid, _SC, _AC, _LG, _RG, defaultLG, defaultRG
   , GradientStop(..), stopColor, stopFraction, mkStops
   , SpreadMethod(..), lineLGradient, lineRGradient
 
@@ -77,6 +78,7 @@ import           Diagrams.Located            (unLoc)
 import           Diagrams.Path               (Path, pathTrails)
 import           Diagrams.Trail              (isLoop)
 import           Diagrams.TwoD.Types
+import           Diagrams.Util
 
 
 -----------------------------------------------------------------
@@ -195,6 +197,10 @@ type instance N (Texture n) = n
 
 makePrisms ''Texture
 
+-- | Prism onto an 'AlphaColour' 'Double' of a 'SC' texture.
+_AC :: Prism' (Texture n) (AlphaColour Double)
+_AC = _SC . _SomeColor
+
 instance Floating n => Transformable (Texture n) where
   transform t (LG lg) = LG $ transform t lg
   transform t (RG rg) = RG $ transform t rg
@@ -262,12 +268,6 @@ newtype LineTexture n = LineTexture (Last (Texture n))
   deriving (Typeable, Semigroup)
 instance (Typeable n) => AttributeClass (LineTexture n)
 
-instance Rewrapped (LineTexture n) (LineTexture n')
-instance Wrapped (LineTexture n) where
-  type Unwrapped (LineTexture n) = Texture n
-  _Wrapped' = iso getLineTexture mkLineTexture
-  {-# INLINE _Wrapped' #-}
-
 type instance V (LineTexture n) = V2
 type instance N (LineTexture n) = n
 
@@ -281,7 +281,7 @@ instance Floating n => Transformable (LineTexture n) where
   transform t (LineTexture (Last tx)) = LineTexture (Last $ transform t tx)
 
 instance Default (LineTexture n) where
-  def = LineTexture (Last (SC (SomeColor (black :: Colour Double))))
+  def = _LineTexture . _SC ## SomeColor black
 
 mkLineTexture :: Texture n -> LineTexture n
 mkLineTexture = LineTexture . Last
@@ -289,40 +289,42 @@ mkLineTexture = LineTexture . Last
 getLineTexture :: LineTexture n -> Texture n
 getLineTexture (LineTexture (Last t)) = t
 
-lineTexture :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => Texture n -> a -> a
+lineTexture :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => Texture n -> a -> a
 lineTexture = applyTAttr . LineTexture . Last
 
-lineTextureA :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => LineTexture n -> a -> a
+lineTextureA :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => LineTexture n -> a -> a
 lineTextureA = applyTAttr
 
 _lineTexture :: (Floating n, Typeable n) => Lens' (Style V2 n) (Texture n)
 _lineTexture = atTAttr . anon def isDef . _LineTexture
+  where
+    isDef = anyOf (_LineTexture . _AC) (== opaque black)
 
 -- | Set the line (stroke) color.  This function is polymorphic in the
 --   color type (so it can be used with either 'Colour' or
 --   'AlphaColour'), but this can sometimes create problems for type
 --   inference, so the 'lc' and 'lcA' variants are provided with more
 --   concrete types.
-lineColor :: (Typeable n, Floating n, Color c, HasStyle a, V a ~ V2, N a ~ n) => c -> a -> a
+lineColor :: (InSpace V2 n a, Color c, Typeable n, Floating n, HasStyle a) => c -> a -> a
 lineColor = lineTexture . SC . SomeColor
 
 -- | A synonym for 'lineColor', specialized to @'Colour' Double@
 --   (i.e. opaque colors).  See comment in 'lineColor' about backends.
-lc :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => Colour Double -> a -> a
+lc :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => Colour Double -> a -> a
 lc = lineColor
 
 -- | A synonym for 'lineColor', specialized to @'AlphaColour' Double@
 --   (i.e. colors with transparency).  See comment in 'lineColor'
 --   about backends.
-lcA :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => AlphaColour Double -> a -> a
+lcA :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => AlphaColour Double -> a -> a
 lcA = lineColor
 
 -- | Apply a linear gradient.
-lineLGradient :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => LGradient n -> a -> a
+lineLGradient :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => LGradient n -> a -> a
 lineLGradient g = lineTexture (LG g)
 
 -- | Apply a radial gradient.
-lineRGradient :: (Typeable n, Floating n, HasStyle a, V a ~ V2, N a ~ n) => RGradient n -> a -> a
+lineRGradient :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => RGradient n -> a -> a
 lineRGradient g = lineTexture (RG g)
 
 -- Fill Texture --------------------------------------------------------
@@ -332,12 +334,6 @@ lineRGradient g = lineTexture (RG g)
 --   is that of 'Recommed . Last'.
 newtype FillTexture n = FillTexture (Recommend (Last (Texture n)))
   deriving (Typeable, Semigroup)
-
-instance Rewrapped (FillTexture n) (FillTexture n')
-instance Wrapped (FillTexture n) where
-  type Unwrapped (FillTexture n) = Texture n
-  _Wrapped' = iso getFillTexture mkFillTexture
-  {-# INLINE _Wrapped' #-}
 
 instance Typeable n => AttributeClass (FillTexture n)
 
@@ -360,12 +356,12 @@ instance Floating n => Transformable (FillTexture n) where
   transform = over (_FillTexture . _recommend) . transform
 
 instance Default (FillTexture n) where
-  def = review (_FillTexture . _Recommend . _SC . _SomeColor) transparent
+  def = mkFillTexture $ _AC ## transparent
 
 getFillTexture :: FillTexture n -> Texture n
 getFillTexture (FillTexture tx) = getLast . getRecommend $ tx
 
-fillTexture :: (HasStyle a, V a ~ V2, N a ~ n, Typeable n, Floating n) => Texture n -> a -> a
+fillTexture :: (InSpace V2 n a, Typeable n, Floating n, HasStyle a) => Texture n -> a -> a
 fillTexture = applyTAttr . mkFillTexture
 
 mkFillTexture :: Texture n -> FillTexture n
@@ -375,11 +371,10 @@ mkFillTexture = FillTexture . Commit . Last
 _fillTextureR :: (Typeable n, Floating n) => Lens' (Style V2 n) (Recommend (Texture n))
 _fillTextureR = atTAttr . anon def isDef . _FillTexture
   where
-    isDef (FillTexture (Recommend (Last (SC sc)))) = toAlphaColour sc == transparent
-    isDef _                                        = False
+    isDef = anyOf (_FillTexture . _Recommend . _AC) (== transparent)
 
--- | Commit a fill texture in a style. This is *not* a valid lens
---   because the resulting texture is always 'Commit' (see 'committed').
+-- | Commit a fill texture in a style. This is /not/ a valid setter
+--   because it doesn't abide the functor law (see 'committed').
 _fillTexture :: (Typeable n, Floating n) => Lens' (Style V2 n) (Texture n)
 _fillTexture = _fillTextureR . committed
 
@@ -387,24 +382,24 @@ _fillTexture = _fillTextureR . committed
 --   type (so it can be used with either 'Colour' or 'AlphaColour'),
 --   but this can sometimes create problems for type inference, so the
 --   'fc' and 'fcA' variants are provided with more concrete types.
-fillColor :: (Color c, HasStyle a, V a ~ V2, N a ~ n, Typeable n, Floating n) => c -> a -> a
+fillColor :: (InSpace V2 n a, Color c, Typeable n, Floating n, HasStyle a) => c -> a -> a
 fillColor = fillTexture . SC . SomeColor
 
 -- | Set a \"recommended\" fill color, to be used only if no explicit
 --   calls to 'fillColor' (or 'fc', or 'fcA') are used.
 --   See comment after 'fillColor' about backends.
-recommendFillColor :: (Color c, HasStyle a, V a ~ V2, N a ~ n, Typeable n, Floating n) => c -> a -> a
+recommendFillColor :: (InSpace V2 n a, Color c, Typeable n, Floating n, HasStyle a) => c -> a -> a
 recommendFillColor =
   applyTAttr . FillTexture . Recommend . Last . SC . SomeColor
 
 -- | A synonym for 'fillColor', specialized to @'Colour' Double@
 --   (i.e. opaque colors). See comment after 'fillColor' about backends.
-fc :: (HasStyle a, V a ~ V2, N a ~ n, Floating n, Typeable n) => Colour Double -> a -> a
+fc :: (InSpace V2 n a, Floating n, Typeable n, HasStyle a) => Colour Double -> a -> a
 fc = fillColor
 
 -- | A synonym for 'fillColor', specialized to @'AlphaColour' Double@
 --   (i.e. colors with transparency). See comment after 'fillColor' about backends.
-fcA :: (HasStyle a, V a ~ V2, N a ~ n, Floating n, Typeable n) => AlphaColour Double -> a -> a
+fcA :: (InSpace V2 n a, Floating n, Typeable n, HasStyle a) => AlphaColour Double -> a -> a
 fcA = fillColor
 
 -- Split fills ---------------------------------------------------------

--- a/src/Diagrams/TwoD/Combinators.hs
+++ b/src/Diagrams/TwoD/Combinators.hs
@@ -31,7 +31,7 @@ module Diagrams.TwoD.Combinators
 
     , extrudeLeft, extrudeRight, extrudeBottom, extrudeTop
 
-    , view
+    , rectEnvelope
 
     , boundingRect, bg, bgFrame
 
@@ -235,14 +235,14 @@ extrudeTop s
   | s >= 0    = extrudeEnvelope $ unitY ^* s
   | otherwise = intrudeEnvelope $ unitY ^* s
 
--- | @view p v@ sets the envelope of a diagram to a rectangle whose
+-- | @boxEnvelope p v@ sets the envelope of a diagram to a rectangle whose
 --   lower-left corner is at @p@ and whose upper-right corner is at @p
 --   .+^ v@.  Useful for selecting the rectangular portion of a
 --   diagram which should actually be \"viewed\" in the final render,
 --   if you don't want to see the entire diagram.
-view :: forall b n m. (OrderedField n, Monoid' m)
+rectEnvelope :: forall b n m. (OrderedField n, Monoid' m)
      => Point V2 n -> V2 n -> QDiagram b V2 n m -> QDiagram b V2 n m
-view p (V2 w h) = withEnvelope (rect w h # alignBL # moveTo p :: Path V2 n)
+rectEnvelope p (V2 w h) = withEnvelope (rect w h # alignBL # moveTo p :: Path V2 n)
 
 -- | Construct a bounding rectangle for an enveloped object, that is,
 --   the smallest axis-aligned rectangle which encloses the object.

--- a/src/Diagrams/TwoD/Combinators.hs
+++ b/src/Diagrams/TwoD/Combinators.hs
@@ -60,8 +60,8 @@ import           Diagrams.TwoD.Vector
 import           Diagrams.Util            (( # ))
 
 import           Linear.Affine
-import           Linear.Vector
 import           Linear.Metric
+import           Linear.Vector
 
 infixl 6 ===
 infixl 6 |||
@@ -235,7 +235,7 @@ extrudeTop s
   | s >= 0    = extrudeEnvelope $ unitY ^* s
   | otherwise = intrudeEnvelope $ unitY ^* s
 
--- | @boxEnvelope p v@ sets the envelope of a diagram to a rectangle whose
+-- | @rectEnvelope p v@ sets the envelope of a diagram to a rectangle whose
 --   lower-left corner is at @p@ and whose upper-right corner is at @p
 --   .+^ v@.  Useful for selecting the rectangular portion of a
 --   diagram which should actually be \"viewed\" in the final render,

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -45,7 +45,8 @@ module Diagrams.TwoD.Path
 
          -- * Clipping
 
-       , Clip(..), clipBy, clipTo, clipped
+       , Clip(..), _Clip, _clip
+       , clipBy, clipTo, clipped
 
          -- * Intersections
 
@@ -55,10 +56,7 @@ module Diagrams.TwoD.Path
        ) where
 
 import           Control.Applicative       (liftA2)
-import           Control.Lens              (Lens, Lens', generateSignatures,
-                                            lensRules, makeLensesWith,
-                                            makeWrapped, op, (.~), (^.),
-                                            _Wrapped')
+import           Control.Lens              hiding (transform, at)
 import qualified Data.Foldable             as F
 import           Data.Semigroup
 import           Data.Typeable
@@ -374,11 +372,21 @@ makeWrapped ''Clip
 
 instance Typeable n => AttributeClass (Clip n)
 
+instance AsEmpty (Clip n) where
+  _Empty = _Clip . _Empty
+
 type instance V (Clip n) = V2
 type instance N (Clip n) = n
 
 instance (OrderedField n) => Transformable (Clip n) where
   transform t (Clip ps) = Clip (transform t ps)
+
+_Clip :: Iso (Clip n) (Clip n') [Path V2 n] [Path V2 n']
+_Clip = _Wrapped
+
+-- | Lens onto the Clip in a style. An empty list means no clipping.
+_clip :: Typeable n => Lens' (Style v n) [Path V2 n]
+_clip = atAttr . non' _Empty . _Clip
 
 -- | Clip a diagram by the given path:
 --

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -84,9 +84,10 @@ instance Floating n => Renderable (Text n) NullBackend where
 -- | @TextAlignment@ specifies the alignment of the text's origin.
 data TextAlignment n = BaselineText | BoxAlignedText n n
 
+-- | Make a text from a 'TextAlignment'.
 mkText :: (TypeableFloat n, Renderable (Text n) b)
   => TextAlignment n -> String -> QDiagram b V2 n Any
-mkText a t = recommendFillColor (black :: Colour Double)
+mkText a t = recommendFillColor black
              -- See Note [recommendFillColor]
            . recommendFontSize (local 1)
              -- See Note [recommendFontSize]
@@ -344,3 +345,4 @@ bold = fontWeight FontWeightBold
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight
 _fontWeight = atAttr . mapping _FontWeight . non def
+

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -35,7 +35,7 @@ module Diagrams.TwoD.Text (
   , FontSlant(..), FontSlantA, _FontSlant
   , getFontSlant, fontSlant, italic, oblique, _fontSlant
   -- ** Font weight
-  , FontWeight(..), FontWeightA, _FontWeight
+  , FontWeight(..)
   , getFontWeight, fontWeight, bold, _fontWeight
   ) where
 
@@ -311,32 +311,31 @@ oblique = fontSlant FontSlantOblique
 --------------------------------------------------
 -- Font weight
 
-data FontWeight = FontWeightNormal
-                | FontWeightBold
-    deriving (Eq, Show)
-
 -- | The @FontWeightA@ attribute specifies the weight (normal or bold)
 --   that should be used for all text within a diagram.  Inner
 --   @FontWeightA@ attributes override outer ones.
-newtype FontWeightA = FontWeightA (Last FontWeight)
-  deriving (Typeable, Semigroup, Eq)
-instance AttributeClass FontWeightA
+data FontWeight = FontWeightNormal
+                | FontWeightBold
+    deriving (Eq, Ord, Show, Typeable)
+
+instance AttributeClass FontWeight
+
+-- | Last semigroup structure
+instance Semigroup FontWeight where
+  _ <> b = b
 
 instance Default FontWeight where
   def = FontWeightNormal
 
-_FontWeight :: Iso' FontWeightA FontWeight
-_FontWeight = iso getFontWeight (FontWeightA . Last)
-
--- | Extract the font weight from a 'FontWeightA' attribute.
-getFontWeight :: FontWeightA -> FontWeight
-getFontWeight (FontWeightA (Last w)) = w
+-- | Extract the font weight.
+getFontWeight :: FontWeight -> FontWeight
+getFontWeight = id
 
 -- | Specify the weight (normal or bold) that should be
 --   used for all text within a diagram.  See also 'bold'
 --   for a useful special case.
 fontWeight :: HasStyle a => FontWeight -> a -> a
-fontWeight = applyAttr . FontWeightA . Last
+fontWeight = applyAttr
 
 -- | Set all text using a bold font weight.
 bold :: HasStyle a => a -> a
@@ -344,5 +343,5 @@ bold = fontWeight FontWeightBold
 
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight
-_fontWeight = atAttr . mapping _FontWeight . non def
+_fontWeight = atAttr . non def
 

--- a/src/Diagrams/TwoD/Vector.hs
+++ b/src/Diagrams/TwoD/Vector.hs
@@ -15,7 +15,7 @@ module Diagrams.TwoD.Vector
        , xDir, yDir
 
          -- * Converting between vectors and angles
-       , e, angleDir
+       , angleV, angleDir, e
 
          -- * 2D vector utilities
        , perp, leftTurn, cross2
@@ -54,14 +54,19 @@ xDir = dir unitX
 yDir :: (R2 v, Additive v, Num n) => Direction v n
 yDir = dir unitY
 
+-- | A direction at a specified angle counter-clockwise from the 'xDir'.
+angleDir :: Floating n => Angle n -> Direction V2 n
+angleDir = dir . angleV
+
+-- | A unit vector at a specified angle counter-clockwise from the
+--   positive x-axis
+angleV :: Floating n => Angle n -> V2 n
+angleV = angle . view rad
+
 -- | A unit vector at a specified angle counter-clockwise from the
 --   positive X axis.
 e :: Floating n => Angle n -> V2 n
-e = angle . view rad
-
--- | A direction at a specified angle counter-clockwise from the 'xDir'.
-angleDir :: Floating n => Angle n -> Direction V2 n
-angleDir = dir . e
+e = angleV
 
 -- | @leftTurn v1 v2@ tests whether the direction of @v2@ is a left
 --   turn from @v1@ (that is, if the direction of @v2@ can be obtained

--- a/src/Diagrams/Util.hs
+++ b/src/Diagrams/Util.hs
@@ -15,6 +15,7 @@ module Diagrams.Util
          with
        , applyAll
        , (#)
+       , (##)
 
        , iterateN
 
@@ -27,6 +28,7 @@ module Diagrams.Util
 
 import           Data.Default.Class
 import           Data.Monoid
+import           Control.Lens hiding (( # ))
 
 -- | Several functions exported by the diagrams library take a number
 --   of arguments giving the user control to \"tweak\" various aspects
@@ -66,6 +68,13 @@ infixl 8 #
 --   like @(|||)@ or @(\<\>)@ without needing parentheses.
 (#) :: a -> (a -> b) -> b
 (#) = flip ($)
+
+-- | A replacement for lenses' @#@ operator. @(##) = 'review'@.
+(##) :: AReview t b -> b -> t
+(##) = review
+{-# INLINE (##) #-}
+infixr 8 ##
+
 
 -- | @iterateN n f x@ returns the list of the first @n@ iterates of
 --   @f@ starting at @x@, that is, the list @[x, f x, f (f x), ...]@


### PR DESCRIPTION
This is a bunch of miscellaneous changes I wanted to make for 1.3. I've tried to make each commit a separate feature. The main changes are:

##### Specialise `Colour` and `AlphaColour` `Color` instances to `Double`
This means you can write `fillColour black` without a type signature on `black`. If you happen to be working with a `Colour Float` you can use `colourConvert`.

##### Move (`|>`) (qualify object with `Name`) to (`>|`)
This cleans up space for lenses snoc operator to use with `Line`s new `Cons` and `Snoc` instances.

##### Remove `LineJoinA` and `LineCapA`
I'm not too bothered about this, it just seemed silly to make a `newtype` around `Last` just for the instance.

##### Move `view` to `rectEnvelope`
I'm open to name suggestions but I use `view` a lot from lens and I always forget and get horrible error messages. Also I don't think `view`s a great name because anything outside the box is still visible, it just happens to hide it if you use it on the final diagram.

##### New show instances
The new show instances hide the internal representation and can be copy pasted to form valid Haskell when possible. `Attribute` and `Style` instances show the name of type they're holding which is useful for debugging

##### Export lens from prelude
It doesn't have to be the whole of lens but I'd like a lot more. Importing lens separately makes a few annoying clashing and it is a prelude after all :)