### PR TITLE
angleBetween uses cross product for sign

### DIFF
--- a/src/Diagrams/Angle.hs
+++ b/src/Diagrams/Angle.hs
@@ -49,6 +49,7 @@ import           Diagrams.Points
 
 import           Linear.Metric
 import           Linear.Vector
+import           Linear.V2
 
 -- | Angles can be expressed in a variety of units.  Internally,
 --   they are represented in radians.
@@ -197,11 +198,14 @@ a @@ i = review i a
 
 infixl 5 @@
 
--- | Compute the positive angle between the two vectors in their common plane.
+-- | Compute the angle between the two vectors in their common plane.
+--   The angle has a sign depending on the cross product of the vectors.
 --   Returns NaN if either of the vectors are zero.
-angleBetween  :: (Metric v, Floating n) => v n -> v n -> Angle n
-angleBetween v1 v2 = acosA (signorm v1 `dot` signorm v2)
--- N.B.: Currently discards the common plane information.
+angleBetween  :: (Metric v, Floating n, Ord n, R2 v) => v n -> v n -> Angle n
+angleBetween v1 v2 = Radians (crossSign * (acos (signorm v1 `dot` signorm v2))) where
+   cross = v1^._x * v2^._y - v1^._y * v2^._x
+   crossSign | cross >= 0 =  1
+             | otherwise  = -1
 
 -- | Normalize an angle so that it lies in the [0,tau) range.
 normalizeAngle :: (Floating n, Real n) => Angle n -> Angle n

--- a/src/Diagrams/Direction.hs
+++ b/src/Diagrams/Direction.hs
@@ -29,6 +29,7 @@ import           Diagrams.Core
 import           Linear.Affine
 import           Linear.Vector
 import           Linear.Metric
+import           Linear.V2
 
 --------------------------------------------------------------------------------
 -- Direction
@@ -76,7 +77,7 @@ fromDir :: (Metric v, Floating n) => Direction v n -> v n
 fromDir (Dir v) = signorm v
 
 -- | compute the positive angle between the two directions in their common plane
-angleBetweenDirs :: (Metric v, Floating n)
+angleBetweenDirs :: (Metric v, Floating n, Ord n, R2 v)
   => Direction v n -> Direction v n -> Angle n
 angleBetweenDirs d1 d2 = angleBetween (fromDirection d1) (fromDirection d2)
 

--- a/src/Diagrams/ThreeD/Transform.hs
+++ b/src/Diagrams/ThreeD/Transform.hs
@@ -138,18 +138,18 @@ rotateAbout p d theta = transform (rotationAbout p d theta)
 -- without tilting, it will be, otherwise if only tilting is
 -- necessary, no panning will occur.  The tilt will always be between
 -- ± 1/4 turn.
-pointAt :: Floating n
+pointAt :: (Floating n, Ord n)
         => Direction V3 n -> Direction V3 n -> Direction V3 n
         -> Transformation V3 n
 pointAt a i f = pointAt' (fromDirection a) (fromDirection i) (fromDirection f)
 
 -- | pointAt' has the same behavior as 'pointAt', but takes vectors
 -- instead of directions.
-pointAt' :: Floating n => V3 n -> V3 n -> V3 n -> Transformation V3 n
+pointAt' :: (Floating n, Ord n) => V3 n -> V3 n -> V3 n -> Transformation V3 n
 pointAt' about initial final = pointAtUnit (signorm about) (signorm initial) (signorm final)
 
 -- | pointAtUnit has the same behavior as @pointAt@, but takes unit vectors.
-pointAtUnit :: Floating n => V3 n -> V3 n -> V3 n -> Transformation V3 n
+pointAtUnit :: (Floating n, Ord n) => V3 n -> V3 n -> V3 n -> Transformation V3 n
 pointAtUnit about initial final = tilt <> pan where
   -- rotating u by (signedAngle rel u v) about rel gives a vector in the direction of v
   signedAngle rel u v = signum (cross u v `dot` rel) *^ angleBetween u v


### PR DESCRIPTION
Accepting this patch is important for the arc command of the svg path-parser in diagrams-input.
After this patch it holds that:
angleBetween v1 v2 == - (angleBetween v2 v1)

which is in my opinion better than
angleBetween v1 v2 == angleBetween v2 v1

In case an absolute value is needed, use:     abs (angleBetween v1 v2)