### PR TITLE
Queries

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -129,7 +129,7 @@ Library
                        text >= 0.7.1 && < 1.3,
                        mtl >= 2.0 && < 2.3,
                        transformers >= 0.3.0 && < 0.5.0,
-                       profunctors,
+                       profunctors >= 0.5 && < 0.6,
                        exceptions >= 0.6 && < 1.0
   if impl(ghc < 7.6)
     Build-depends: ghc-prim

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -129,6 +129,7 @@ Library
                        text >= 0.7.1 && < 1.3,
                        mtl >= 2.0 && < 2.3,
                        transformers >= 0.3.0 && < 0.5.0,
+                       profunctors,
                        exceptions >= 0.6 && < 1.0
   if impl(ghc < 7.6)
     Build-depends: ghc-prim

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -129,7 +129,7 @@ Library
                        text >= 0.7.1 && < 1.3,
                        mtl >= 2.0 && < 2.3,
                        transformers >= 0.3.0 && < 0.5.0,
-                       profunctors >= 0.5 && < 0.6,
+                       profunctors >= 5.0 && < 6.0,
                        exceptions >= 0.6 && < 1.0
   if impl(ghc < 7.6)
     Build-depends: ghc-prim

--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -75,7 +75,7 @@ module Diagrams.Backend.CmdLine
 import           Control.Lens              (Lens', makeLenses, (&), (.~), (^.))
 import           Diagrams.Animation
 import           Diagrams.Attributes
-import           Diagrams.Core             hiding (output, value)
+import           Diagrams.Core             hiding (output)
 import           Diagrams.Util
 
 import           Options.Applicative

--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -38,7 +38,7 @@ module Diagrams.BoundingBox
   , boxExtents, boxCenter
   , mCenterPoint, centerPoint
   , boxTransform, boxFit
-  , contains, contains', boundingBoxQuery
+  , contains, contains'
   , inside, inside', outside, outside'
 
     -- * Operations on bounding boxes
@@ -55,6 +55,7 @@ import           Diagrams.Align
 import           Diagrams.Core
 import           Diagrams.Core.Transform
 import           Diagrams.Path
+import           Diagrams.Query          hiding (inside)
 import           Diagrams.ThreeD.Shapes  (cube)
 import           Diagrams.ThreeD.Types
 import           Diagrams.TwoD.Path      ()
@@ -118,8 +119,12 @@ instance (Additive v, Num n, Ord n) => HasOrigin (BoundingBox v n) where
     = fromMaybeEmpty
     (NonEmptyBoundingBox . mapT (moveOriginTo p) <$> getCorners b)
 
+instance (Additive v, Foldable v, Num n, Ord n)
+     => HasQuery (BoundingBox v n) Any where
+  getQuery bb = Query $ Any . contains bb
+
 instance (Metric v, Traversable v, OrderedField n)
-          => Enveloped (BoundingBox v n) where
+     => Enveloped (BoundingBox v n) where
   getEnvelope = getEnvelope . getAllCorners
 
 -- Feels like cheating.
@@ -254,9 +259,6 @@ contains' b p = maybe False check $ getCorners b
   where
     check (l, h) = F.and (liftI2 (<) l p)
                 && F.and (liftI2 (<) p h)
-
-boundingBoxQuery :: (Additive v, Foldable v, Ord n) => BoundingBox v n -> Query v n Any
-boundingBoxQuery bb = Query $ Any . contains bb
 
 -- | Test whether the first bounding box is contained inside
 --   the second.

--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -55,7 +55,7 @@ import           Diagrams.Align
 import           Diagrams.Core
 import           Diagrams.Core.Transform
 import           Diagrams.Path
-import           Diagrams.Query          hiding (inside)
+import           Diagrams.Query
 import           Diagrams.ThreeD.Shapes  (cube)
 import           Diagrams.ThreeD.Types
 import           Diagrams.TwoD.Path      ()

--- a/src/Diagrams/Query.hs
+++ b/src/Diagrams/Query.hs
@@ -45,10 +45,24 @@ instance Monoid m => HasQuery (QDiagram b v n m) m where
   getQuery = query
 
 -- | Test if a point is not equal to 'mempty'.
+--
+-- @
+-- 'inside' :: 'QDiagram' b v n 'Any' -> 'Point' v n -> 'Bool'
+-- 'inside' :: 'Query' v n 'Any'      -> 'Point' v n -> 'Bool'
+-- 'inside' :: 'Diagrams.BoundingBox.BoundingBox' v n  -> 'Point' v n -> 'Bool'
+-- 'inside' :: 'Diagrams.Path.Path' 'V2' 'Double'   -> 'Point' v n -> 'Bool'
+-- @
 inside :: (HasQuery t m, Monoid m, Eq m) => t -> Point (V t) (N t) -> Bool
 inside t = (/= mempty) . sample t
 
 -- | Sample a diagram's query function at a given point.
+--
+-- @
+-- 'sample' :: 'QDiagram' b v n m -> 'Point' v n -> m
+-- 'sample' :: 'Query' v n m      -> 'Point' v n -> m
+-- 'sample' :: 'Diagrams.BoundingBox.BoundingBox' v n  -> 'Point' v n -> 'Any'
+-- 'sample' :: 'Diagrams.Path.Path' 'V2' 'Double'   -> 'Point' v n -> 'Diagrams.TwoD.Path.Crossings'
+-- @
 sample :: HasQuery t m => t -> Point (V t) (N t) -> m
 sample = runQuery . getQuery
 

--- a/src/Diagrams/ThreeD.hs
+++ b/src/Diagrams/ThreeD.hs
@@ -4,7 +4,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.ThreeD
--- Copyright   :  (c) 2013 diagrams-lib team (see LICENSE)
+-- Copyright   :  (c) 2013-2015 diagrams-lib team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -40,24 +40,23 @@
 --     highlights.
 -----------------------------------------------------------------------------
 module Diagrams.ThreeD
-       (
-         module Diagrams.ThreeD.Align
-       , module Diagrams.ThreeD.Attributes
-       , module Diagrams.ThreeD.Camera
-       , module Diagrams.ThreeD.Deform
-       , module Diagrams.ThreeD.Light
-       , module Diagrams.ThreeD.Shapes
-       , module Diagrams.ThreeD.Transform
-       , module Diagrams.ThreeD.Types
-       , module Diagrams.ThreeD.Vector
-       ) where
+  ( module Diagrams.ThreeD.Align
+  , module Diagrams.ThreeD.Attributes
+  , module Diagrams.ThreeD.Camera
+  , module Diagrams.ThreeD.Deform
+  , module Diagrams.ThreeD.Light
+  , module Diagrams.ThreeD.Shapes
+  , module Diagrams.ThreeD.Transform
+  , module Diagrams.ThreeD.Types
+  , module Diagrams.ThreeD.Vector
+  ) where
 
 import           Diagrams.ThreeD.Align
 import           Diagrams.ThreeD.Attributes
 import           Diagrams.ThreeD.Camera
 import           Diagrams.ThreeD.Deform
 import           Diagrams.ThreeD.Light
-import           Diagrams.ThreeD.Shapes     hiding (Inside)
+import           Diagrams.ThreeD.Shapes
 import           Diagrams.ThreeD.Transform
 import           Diagrams.ThreeD.Types
 import           Diagrams.ThreeD.Vector

--- a/src/Diagrams/ThreeD/Shapes.hs
+++ b/src/Diagrams/ThreeD/Shapes.hs
@@ -17,14 +17,28 @@
 -----------------------------------------------------------------------------
 
 module Diagrams.ThreeD.Shapes
-     (
-     Ellipsoid(..), sphere
-     , Box(..), cube
-     , Frustum(..) , frustum, cone, cylinder
-     , Skinned(..)
-     , CSG(..), union, intersection, difference
-     , Inside(..)
-     ) where
+  (
+    -- * Skinned class
+    Skinned(..)
+
+    -- * Basic 3D shapes
+  , Ellipsoid(..)
+  , sphere
+
+  , Box(..)
+  , cube
+
+  , Frustum(..)
+  , frustum
+  , cone
+  , cylinder
+
+    -- * Constructive solid geometry
+  , CSG(..)
+  , union
+  , intersection
+  , difference
+  ) where
 
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
@@ -38,6 +52,7 @@ import           Diagrams.Angle
 import           Diagrams.Core
 import           Diagrams.Core.Trace
 import           Diagrams.Points
+import           Diagrams.Query
 import           Diagrams.Solve.Polynomial
 import           Diagrams.ThreeD.Types
 import           Diagrams.ThreeD.Vector
@@ -171,31 +186,27 @@ cone = frustum 1 0
 cylinder :: Num n => Frustum n
 cylinder = frustum 1 1
 
--- | Types which can answer a Query about points inside the geometric object.
-class Inside t where
-  inside :: t -> Query (V t) (N t) Any
-
 -- | Types which can be rendered as 3D Diagrams.
 class Skinned t where
-  skin :: (Renderable t b, N t ~ n, TypeableFloat n) => t  -> QDiagram b V3 n Any
+  skin :: (Renderable t b, N t ~ n, TypeableFloat n) => t -> QDiagram b V3 n Any
 
-instance (Num n, Ord n) => Inside (Ellipsoid n) where
-  inside (Ellipsoid tr) = transform tr $
-              Query $ \v -> Any $ quadrance (v .-. origin) <= 1
+instance (Num n, Ord n) => HasQuery (Ellipsoid n) Any where
+  getQuery (Ellipsoid tr) = transform tr $
+    Query $ \v -> Any $ quadrance (v .-. origin) <= 1
 
 instance OrderedField n => Skinned (Ellipsoid n) where
-  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (inside s)
+  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (getQuery s)
 
-instance (Num n, Ord n) => Inside (Box n) where
-  inside (Box tr) = transform tr . Query $ Any . range where
+instance (Num n, Ord n) => HasQuery (Box n) Any where
+  getQuery (Box tr) = transform tr . Query $ Any . range where
     range u = and [x >= 0, x <= 1, y >= 0, y <= 1, z >= 0, z <= 1] where
       (x, y, z) = unp3 u
 
 instance OrderedField n => Skinned (Box n) where
-  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (inside s)
+  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (getQuery s)
 
-instance (OrderedField n) => Inside (Frustum n) where
-  inside (Frustum r0 r1 tr)= transform tr $
+instance (OrderedField n) => HasQuery (Frustum n) Any where
+  getQuery (Frustum r0 r1 tr)= transform tr $
     Query $ \p -> let
       z = p^._z
       r = r0 + (r1 - r0)*z
@@ -206,7 +217,7 @@ instance (OrderedField n) => Inside (Frustum n) where
        Any $ z >= 0 && z <= 1 && a <= r
 
 instance Skinned (Frustum n) where
-  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (inside s)
+  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (getQuery s)
 
 -- The CSG type needs to form a tree to be useful.  This
 -- implementation requires Backends to support all the included
@@ -220,13 +231,14 @@ instance Skinned (Frustum n) where
 
 -- | A tree of Constructive Solid Geometry operations and the primitives that
 -- can be used in them.
-data CSG n = CsgEllipsoid (Ellipsoid n)
-     | CsgBox (Box n)
-     | CsgFrustum (Frustum n)
-     | CsgUnion [CSG n]
-     | CsgIntersection [CSG n]
-     | CsgDifference (CSG n) (CSG n)
-       deriving Typeable
+data CSG n
+  = CsgEllipsoid (Ellipsoid n)
+  | CsgBox (Box n)
+  | CsgFrustum (Frustum n)
+  | CsgUnion [CSG n]
+  | CsgIntersection [CSG n]
+  | CsgDifference (CSG n) (CSG n)
+  deriving Typeable
 
 type instance V (CSG n) = V3
 type instance N (CSG n) = n
@@ -251,43 +263,43 @@ instance RealFloat n => Enveloped (CSG n) where
 -- TODO after implementing some approximation scheme, calculate
 -- correct (approximate) envelopes for intersections and difference.
 
-instance (Floating n, Ord n) => Inside (CSG n) where
-  inside (CsgEllipsoid prim) = inside prim
-  inside (CsgBox prim) = inside prim
-  inside (CsgFrustum prim) = inside prim
-  inside (CsgUnion ps) = foldMap inside ps
-  inside (CsgIntersection ps) =
-    Any . getAll <$> foldMap (fmap (All . getAny) . inside) ps
-  inside (CsgDifference p1 p2) = inOut <$> inside p1 <*> inside p2 where
+instance (Floating n, Ord n) => HasQuery (CSG n) Any where
+  getQuery (CsgEllipsoid prim) = getQuery prim
+  getQuery (CsgBox prim) = getQuery prim
+  getQuery (CsgFrustum prim) = getQuery prim
+  getQuery (CsgUnion ps) = foldMap getQuery ps
+  getQuery (CsgIntersection ps) =
+    Any . getAll <$> foldMap (fmap (All . getAny) . getQuery) ps
+  getQuery (CsgDifference p1 p2) = inOut <$> getQuery p1 <*> getQuery p2 where
     inOut (Any a) (Any b) = Any $ a && not b
 
 instance (RealFloat n, Ord n) => Traced (CSG n) where
   getTrace (CsgEllipsoid p) = getTrace p
   getTrace (CsgBox p) = getTrace p
   getTrace (CsgFrustum p) = getTrace p
-  -- on surface of some p, and not inside any of the others
+  -- on surface of some p, and not getQuery any of the others
   getTrace (CsgUnion []) = mempty
   getTrace (CsgUnion (s:ss)) = mkTrace t where
     t pt v = onSortedList (filter $ without s) (appTrace (getTrace (CsgUnion ss)) pt v)
          <> onSortedList (filter $ without (CsgUnion ss)) (appTrace (getTrace s) pt v) where
       newPt dist = pt .+^ v ^* dist
-      without prim = not . getAny . runQuery (inside prim) . newPt
-  -- on surface of some p, and inside all the others
+      without prim = not . getAny . runQuery (getQuery prim) . newPt
+  -- on surface of some p, and getQuery all the others
   getTrace (CsgIntersection []) = mempty
   getTrace (CsgIntersection (s:ss)) = mkTrace t where
     t pt v = onSortedList (filter $ within s) (appTrace (getTrace (CsgIntersection ss)) pt v)
          <> onSortedList (filter $ within (CsgIntersection ss)) (appTrace (getTrace s) pt v) where
       newPt dist = pt .+^ v ^* dist
-      within prim = getAny . runQuery (inside prim) . newPt
-  -- on surface of p1, outside p2, or on surface of p2, inside p1
+      within prim = getAny . runQuery (getQuery prim) . newPt
+  -- on surface of p1, outside p2, or on surface of p2, getQuery p1
   getTrace (CsgDifference s1 s2) = mkTrace t where
     t pt v = onSortedList (filter $ not . within s2) (appTrace (getTrace s1) pt v)
          <> onSortedList (filter $ within s1) (appTrace (getTrace s2) pt v) where
       newPt dist = pt .+^ v ^* dist
-      within prim = getAny . runQuery (inside prim) . newPt
+      within prim = getAny . runQuery (getQuery prim) . newPt
 
 instance (RealFloat n, Ord n) => Skinned (CSG n) where
-  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (inside s)
+  skin s = mkQD (Prim s) (getEnvelope s) (getTrace s) mempty (getQuery s)
 
 -- | Types which can be included in CSG trees.
 class CsgPrim a where

--- a/src/Diagrams/ThreeD/Shapes.hs
+++ b/src/Diagrams/ThreeD/Shapes.hs
@@ -277,21 +277,21 @@ instance (RealFloat n, Ord n) => Traced (CSG n) where
   getTrace (CsgEllipsoid p) = getTrace p
   getTrace (CsgBox p) = getTrace p
   getTrace (CsgFrustum p) = getTrace p
-  -- on surface of some p, and not getQuery any of the others
+  -- on surface of some p, and not inside any of the others
   getTrace (CsgUnion []) = mempty
   getTrace (CsgUnion (s:ss)) = mkTrace t where
     t pt v = onSortedList (filter $ without s) (appTrace (getTrace (CsgUnion ss)) pt v)
          <> onSortedList (filter $ without (CsgUnion ss)) (appTrace (getTrace s) pt v) where
       newPt dist = pt .+^ v ^* dist
       without prim = not . getAny . runQuery (getQuery prim) . newPt
-  -- on surface of some p, and getQuery all the others
+  -- on surface of some p, and inside all the others
   getTrace (CsgIntersection []) = mempty
   getTrace (CsgIntersection (s:ss)) = mkTrace t where
     t pt v = onSortedList (filter $ within s) (appTrace (getTrace (CsgIntersection ss)) pt v)
          <> onSortedList (filter $ within (CsgIntersection ss)) (appTrace (getTrace s) pt v) where
       newPt dist = pt .+^ v ^* dist
       within prim = getAny . runQuery (getQuery prim) . newPt
-  -- on surface of p1, outside p2, or on surface of p2, getQuery p1
+  -- on surface of p1, outside p2, or on surface of p2, inside p1
   getTrace (CsgDifference s1 s2) = mkTrace t where
     t pt v = onSortedList (filter $ not . within s2) (appTrace (getTrace s1) pt v)
          <> onSortedList (filter $ within s1) (appTrace (getTrace s2) pt v) where

--- a/src/Diagrams/TwoD/Image.hs
+++ b/src/Diagrams/TwoD/Image.hs
@@ -43,7 +43,9 @@ import           Diagrams.Core
 
 import           Diagrams.Attributes  (colorToSRGBA)
 import           Diagrams.TwoD.Path   (isInsideEvenOdd)
+import           Diagrams.Path        (Path)
 import           Diagrams.TwoD.Shapes (rect)
+import Diagrams.Query
 import           Diagrams.TwoD.Types
 
 import           Linear.Affine
@@ -72,6 +74,12 @@ data DImage :: * -> * -> * where
 type instance V (DImage n a) = V2
 type instance N (DImage n a) = n
 
+instance RealFloat n => HasQuery (DImage n a) Any where
+  getQuery (DImage _ w h _) = -- transform t $
+    Query $ \p -> Any (isInsideEvenOdd r p)
+    where
+    r = rectPath (fromIntegral w) (fromIntegral h)
+
 instance Fractional n => Transformable (DImage n a) where
   transform t1 (DImage iD w h t2) = DImage iD w h (t1 <> t2)
 
@@ -86,10 +94,14 @@ image img
          (getEnvelope r)
          (getTrace r)
          mempty
-         (Query $ \p -> Any (isInsideEvenOdd p r))
+         (Query $ \p -> Any (isInsideEvenOdd r p))
   where
-    r = rect (fromIntegral w) (fromIntegral h)
+    r = rectPath (fromIntegral w) (fromIntegral h)
+    -- should we use the transform here?
     DImage _ w h _ = img
+
+rectPath :: RealFloat n => n -> n -> Path V2 n
+rectPath = rect
 
 -- | Use JuicyPixels to read an image in any format and wrap it in a 'DImage'.
 --   The width and height of the image are set to their actual values.

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -69,6 +69,7 @@ import           Diagrams.Core
 import           Diagrams.Core.Trace
 import           Diagrams.Located          (Located, mapLoc, unLoc)
 import           Diagrams.Parametric
+import           Diagrams.Query
 import           Diagrams.Path
 import           Diagrams.Segment
 import           Diagrams.Solve.Polynomial

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -168,6 +168,13 @@ instance Default (StrokeOpts a) where
 --
 --   See also 'stroke'', which takes an extra options record allowing
 --   its behaviour to be customized.
+--
+-- @
+-- 'stroke' :: 'Path' 'V2' 'Double'                  -> 'Diagram' b
+-- 'stroke' :: 'Located' ('Trail' 'V2' 'Double')       -> 'Diagram' b
+-- 'stroke' :: 'Located' ('Trail'' 'Loop' 'V2' 'Double') -> 'Diagram' b
+-- 'stroke' :: 'Located' ('Trail'' 'Line' 'V2' 'Double') -> 'Diagram' b
+-- @
 stroke :: (InSpace V2 n t, ToPath t, TypeableFloat n, Renderable (Path V2 n) b)
        => t -> QDiagram b V2 n Any
 stroke = strokeP . toPath
@@ -324,6 +331,12 @@ instance RealFloat n => HasQuery (Path V2 n) Crossings where
 --   by testing whether the point's /winding number/ is nonzero. Note
 --   that @False@ is /always/ returned for paths consisting of lines
 --   (as opposed to loops), regardless of the winding number.
+--
+-- @
+-- 'isInsideWinding' :: 'Path' 'V2' 'Double'                  -> 'Point' 'V2' 'Double' -> 'Bool'
+-- 'isInsideWinding' :: 'Located' ('Trail' 'V2' 'Double')       -> 'Point' 'V2' 'Double' -> 'Bool'
+-- 'isInsideWinding' :: 'Located' ('Trail'' 'Loop' 'V2' 'Double') -> 'Point' 'V2' 'Double' -> 'Bool'
+-- @
 isInsideWinding :: HasQuery t Crossings => t -> Point (V t) (N t) -> Bool
 isInsideWinding t = (/= 0) . sample t
 
@@ -333,6 +346,12 @@ isInsideWinding t = (/= 0) . sample t
 --   number of times.  Note that @False@ is /always/ returned for
 --   paths consisting of lines (as opposed to loops), regardless of
 --   the number of crossings.
+--
+-- @
+-- 'isInsideEvenOdd' :: 'Path' 'V2' 'Double'                  -> 'Point' 'V2' 'Double' -> 'Bool'
+-- 'isInsideEvenOdd' :: 'Located' ('Trail' 'V2' 'Double')       -> 'Point' 'V2' 'Double' -> 'Bool'
+-- 'isInsideEvenOdd' :: 'Located' ('Trail'' 'Loop' 'V2' 'Double') -> 'Point' 'V2' 'Double' -> 'Bool'
+-- @
 isInsideEvenOdd :: HasQuery t Crossings => t -> Point (V t) (N t) -> Bool
 isInsideEvenOdd t = odd . sample t
 

--- a/src/Diagrams/TwoD/Path.hs
+++ b/src/Diagrams/TwoD/Path.hs
@@ -339,7 +339,7 @@ isInsideEvenOdd t = odd . sample t
 -- | Compute the sum of /signed/ crossings of a path as we travel in the
 --   positive x direction from a given point.
 crossings :: RealFloat n => Point V2 n -> Path V2 n -> Crossings
-crossings p = foldMap (trailCrossings p) . op Path
+crossings p = F.foldMap (trailCrossings p) . op Path
 
 -- | Compute the sum of signed crossings of a trail starting from the
 --   given point in the positive x direction.
@@ -349,7 +349,7 @@ trailCrossings :: RealFloat n => Point V2 n -> Located (Trail V2 n) -> Crossings
 trailCrossings _ t | not (isLoop (unLoc t)) = 0
 
 trailCrossings p@(unp2 -> (x,y)) tr
-  = foldMap test $ fixTrail tr
+  = F.foldMap test $ fixTrail tr
   where
     test (FLinear a@(unp2 -> (_,ay)) b@(unp2 -> (_,by)))
       | ay <= y && by > y && isLeft a b > 0 =  1


### PR DESCRIPTION
See also diagrams/diagrams-core#88.
Should be ready do merge.

Generalises @bergey's `Inside` classes. I've called it `HasQuery` with a `getQuery` method to be more consistent with other similar classes. It also has an `m` parameter for to support extra queries. Most are just `Any`, `Diagram` and `Query` has `m`.

Path like things have a `Crossings` query that counts the number of crossings in the positive x direction from the query point. `isInsideWinding` and `isInsideEvenOdd` now use this so they can be used on trails and loops as well as paths. (The arguments of these functions where also flipped to be more consistent with other query-like function.)