### PR TITLE
Added extra SVG font weights

### DIFF
--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -350,7 +350,7 @@ data FontWeight = FontWeightNormal
                 | FontWeightMedium
                 | FontWeightSemiBold
                 | FontWeightUltraBold
-                | FontWeightBlack
+                | FontWeightHeavy
     deriving (Eq, Ord, Show, Typeable)
 
 instance AttributeClass FontWeight
@@ -381,8 +381,8 @@ thin :: HasStyle a => a -> a
 thin = fontWeight FontWeightThin
 
 -- | Set all text using a extra light font weight.
-extraLight :: HasStyle a => a -> a
-extraLight = fontWeight FontWeightExtraLight
+ultraLight :: HasStyle a => a -> a
+ultraLight = fontWeight FontWeightUltraLight
 
 -- | Set all text using a light font weight.
 light :: HasStyle a => a -> a
@@ -401,8 +401,8 @@ ultraBold :: HasStyle a => a -> a
 ultraBold = fontWeight FontWeightUltraBold
 
 -- | Set all text using a heavy/black font weight.
-black :: HasStyle a => a -> a
-black = fontWeight FontWeightBlack
+heavy :: HasStyle a => a -> a
+heavy = fontWeight FontWeightHeavy
 
 -- | Set all text to be bolder than the inherited font weight.
 bolder :: HasStyle a => a -> a
@@ -415,3 +415,4 @@ lighter = fontWeight FontWeightLighter
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight
 _fontWeight = atAttr . non def
+

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -43,7 +43,7 @@ module Diagrams.TwoD.Text (
 
   -- ** Font weight
   , FontWeight(..)
-  , getFontWeight, fontWeight, bold, _fontWeight
+  , getFontWeight, fontWeight, bold, bolder, lighter, _fontWeight
 
   ) where
 
@@ -343,6 +343,7 @@ data FontWeight = FontWeightNormal
                 | FontWeightBold
                 | FontWeightBolder
                 | FontWeightLighter
+                | FontWeightInt Int -- user can specify desired font weight
     deriving (Eq, Ord, Show, Typeable)
 
 instance AttributeClass FontWeight
@@ -376,6 +377,9 @@ bolder = fontWeight FontWeightBolder
 lighter :: HasStyle a => a -> a
 lighter = fontWeight FontWeightLighter
 
+-- | Set all text using SVG font weight integer
+fontWeight' :: HasStyle a => Int -> a -> a
+fontWeight' n = fontWeight (FontWeightInt n)
 
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -43,7 +43,8 @@ module Diagrams.TwoD.Text (
 
   -- ** Font weight
   , FontWeight(..)
-  , getFontWeight, fontWeight, bold, bolder, lighter, _fontWeight
+  , getFontWeight, fontWeight, bold, bolder, lighter, _fontWeight, 
+    fontWeight'
 
   ) where
 

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -341,6 +341,8 @@ oblique = fontSlant FontSlantOblique
 --   @FontWeightA@ attributes override outer ones.
 data FontWeight = FontWeightNormal
                 | FontWeightBold
+                | FontWeightBolder
+                | FontWeightLighter
     deriving (Eq, Ord, Show, Typeable)
 
 instance AttributeClass FontWeight
@@ -356,7 +358,7 @@ instance Default FontWeight where
 getFontWeight :: FontWeight -> FontWeight
 getFontWeight = id
 
--- | Specify the weight (normal or bold) that should be
+-- | Specify the weight (normal, bolder, lighter or bold) that should be
 --   used for all text within a diagram.  See also 'bold'
 --   for a useful special case.
 fontWeight :: HasStyle a => FontWeight -> a -> a
@@ -365,6 +367,15 @@ fontWeight = applyAttr
 -- | Set all text using a bold font weight.
 bold :: HasStyle a => a -> a
 bold = fontWeight FontWeightBold
+
+-- | Set all text using bolder font weight.
+bolder :: HasStyle a => a -> a
+bolder = fontWeight FontWeightBolder
+
+-- | Set all text using lighter font weight.
+lighter :: HasStyle a => a -> a
+lighter = fontWeight FontWeightLighter
+
 
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight

--- a/src/Diagrams/TwoD/Text.hs
+++ b/src/Diagrams/TwoD/Text.hs
@@ -43,8 +43,8 @@ module Diagrams.TwoD.Text (
 
   -- ** Font weight
   , FontWeight(..)
-  , getFontWeight, fontWeight, bold, bolder, lighter, _fontWeight, 
-    fontWeight'
+  , getFontWeight, fontWeight, bold, bolder, lighter, _fontWeight
+  , thin, ultraLight, light, medium, semiBold, ultraBold, black
 
   ) where
 
@@ -344,7 +344,13 @@ data FontWeight = FontWeightNormal
                 | FontWeightBold
                 | FontWeightBolder
                 | FontWeightLighter
-                | FontWeightInt Int -- user can specify desired font weight
+                | FontWeightThin
+                | FontWeightUltraLight
+                | FontWeightLight
+                | FontWeightMedium
+                | FontWeightSemiBold
+                | FontWeightUltraBold
+                | FontWeightBlack
     deriving (Eq, Ord, Show, Typeable)
 
 instance AttributeClass FontWeight
@@ -370,17 +376,41 @@ fontWeight = applyAttr
 bold :: HasStyle a => a -> a
 bold = fontWeight FontWeightBold
 
--- | Set all text using bolder font weight.
+-- | Set all text using a thin font weight.
+thin :: HasStyle a => a -> a
+thin = fontWeight FontWeightThin
+
+-- | Set all text using a extra light font weight.
+extraLight :: HasStyle a => a -> a
+extraLight = fontWeight FontWeightExtraLight
+
+-- | Set all text using a light font weight.
+light :: HasStyle a => a -> a
+light = fontWeight FontWeightLight
+
+-- | Set all text using a medium font weight.
+medium :: HasStyle a => a -> a
+medium = fontWeight FontWeightMedium
+
+-- | Set all text using a semi-bold font weight.
+semiBold :: HasStyle a => a -> a
+semiBold = fontWeight FontWeightSemiBold
+
+-- | Set all text using an ultra-bold font weight.
+ultraBold :: HasStyle a => a -> a
+ultraBold = fontWeight FontWeightUltraBold
+
+-- | Set all text using a heavy/black font weight.
+black :: HasStyle a => a -> a
+black = fontWeight FontWeightBlack
+
+-- | Set all text to be bolder than the inherited font weight.
 bolder :: HasStyle a => a -> a
 bolder = fontWeight FontWeightBolder
 
--- | Set all text using lighter font weight.
+-- | Set all text to be lighter than the inherited font weight.
 lighter :: HasStyle a => a -> a
 lighter = fontWeight FontWeightLighter
-
--- | Set all text using SVG font weight integer
-fontWeight' :: HasStyle a => Int -> a -> a
-fontWeight' n = fontWeight (FontWeightInt n)
 
 -- | Lens onto the font weight in a style.
 _fontWeight :: (Typeable n, OrderedField n) => Lens' (Style v n) FontWeight


### PR DESCRIPTION
Created constructors for all the font weights specified on:
http://www.w3.org/TR/SVG/text.html#FontWeightProperty

The suggestion was to name them semibold, light, etc, but I decided to be consistent with SVG's specification.

Also allows integer declarations of font weight.