### PR TITLE
Transform the arrow shaft style

### DIFF
--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -425,7 +425,7 @@ arrow' opts len = mkQD' (DelayedLeaf delayedArrow)
         opts' = opts
           & headStyle  %~ maybe id fillTexture globalLC
           & tailStyle  %~ maybe id fillTexture globalLC
-          & shaftStyle %~ applyStyle sty
+          & shaftStyle %~ applyStyle sty . transform tr
 
         -- The head size, tail size, head gap, and tail gap are obtained
         -- from the style and converted to output units.


### PR DESCRIPTION
Hopefully fixes #274.

It seems to be fixed by applying the transform to the shaft style. I've applied the transform before applying the global style since this (should) already have the transform applied to it.

Here's an example comparing arrow shafts to paths for different dashings:

```.haskell
import Diagrams.Backend.Rasterific.CmdLine
import Diagrams.Prelude

arrows :: Diagram Rasterific
arrows = mconcat
  [ arrowV' (with & shaftStyle %~ dashingL [0.25, 0.25] 0) unitX
  , arrowV' (with & shaftStyle %~ dashingO [5, 5] 0) unitY
  , arrowV' (with & shaftStyle %~ dashingN [0.05, 0.05] 0) unit_X
  , arrowV' (with & shaftStyle %~ dashingG [0.2, 0.2] 0) unit_Y
  , square 2
  ]

straights :: Diagram Rasterific
straights = mconcat
  [ v unitX  # dashingL [0.25, 0.25] 0
  , v unitY  # dashingO [5, 5] 0
  , v unit_X # dashingN [0.05, 0.05] 0
  , v unit_Y # dashingG [0.2, 0.2] 0
  , square 2
  ] where v = stroke . (`at` origin) . straight

main :: IO ()
main = defaultMain . frame 0.2 $
  (arrows    ||| arrows # scale 2)
             ===
  (straights ||| straights # scale 2)
```

![arrow-test](https://cloud.githubusercontent.com/assets/1354887/15839696/b9bf54d2-2c3c-11e6-8d7e-928fc0f406c5.png)
