### PR TITLE
add Action instance for angles acting by rotation

### DIFF
--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -134,7 +134,7 @@ import           Diagrams.Trail
 import           Diagrams.TwoD.Arrowheads
 import           Diagrams.TwoD.Attributes
 import           Diagrams.TwoD.Path        (stroke, strokeT)
-import           Diagrams.TwoD.Transform   (reflectY, rotate, translateX)
+import           Diagrams.TwoD.Transform   (reflectY, translateX)
 import           Diagrams.TwoD.Types
 import           Diagrams.TwoD.Vector      (unitX, unit_X)
 import           Diagrams.Util             (( # ))

--- a/src/Diagrams/TwoD/Polygons.hs
+++ b/src/Diagrams/TwoD/Polygons.hs
@@ -67,7 +67,6 @@ import           Diagrams.Path
 import           Diagrams.Points         (centroid)
 import           Diagrams.Trail
 import           Diagrams.TrailLike
-import           Diagrams.TwoD.Transform
 import           Diagrams.TwoD.Types
 import           Diagrams.TwoD.Vector    (leftTurn, unitX, unitY, unit_Y)
 import           Diagrams.Util           (tau, ( # ))

--- a/src/Diagrams/TwoD/Transform.hs
+++ b/src/Diagrams/TwoD/Transform.hs
@@ -63,42 +63,12 @@ import           Control.Lens            hiding (at, transform)
 import           Data.Semigroup
 
 import           Linear.Affine
-import           Linear.Vector
 import           Linear.V2
+import           Linear.Vector
 
 -- Rotation ------------------------------------------------
 
--- | Create a transformation which performs a rotation about the local
---   origin by the given angle.  See also 'rotate'.
-
-
-
-rotation :: Floating n => Angle n -> T2 n
-rotation theta = fromLinear r (linv r)
-    where
-    c = cosA theta
-    s = sinA theta
-    r               = rot c s <-> rot c (-s)
-    rot co si (V2 x y) = V2 (co * x - si * y)
-                            (si * x + co * y)
-
-
--- | Rotate about the local origin by the given angle. Positive angles
---   correspond to counterclockwise rotation, negative to
---   clockwise. The angle can be expressed using any of the 'Iso's on
---   'Angle'.  For example, @rotate (1\/4 \@\@ 'turn')@, @rotate
---   (tau\/4 \@\@ rad)@, and @rotate (90 \@\@ deg)@ all
---   represent the same transformation, namely, a counterclockwise
---   rotation by a right angle.  To rotate about some point other than
---   the local origin, see 'rotateAbout'.
---
---   Note that writing @rotate (1\/4)@, with no 'Angle' constructor,
---   will yield an error since GHC cannot figure out which sort of
---   angle you want to use.  In this common situation you can use
---   'rotateBy', which interprets its argument as a number of turns.
-
-rotate :: (InSpace V2 n t, Transformable t, Floating n) => Angle n -> t -> t
-rotate = transform . rotation
+-- For the definitions of 'rotation' and 'rotate', see Diagrams.Angle.
 
 -- | A synonym for 'rotate', interpreting its argument in units of
 -- turns; it can be more convenient to write @rotateBy (1\/4)@ than


### PR DESCRIPTION
Also necessitates moving definitions of 'rotation' and 'rotate' from
Diagrams.TwoD.Transform to Diagrams.Angle to avoid an import cycle.