### PR TITLE
Increase base & directory upper-bounds

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -155,7 +155,7 @@ test-suite tests
                , Diagrams.Test.Angle
                , Instances
   hs-source-dirs: test
-  build-depends:       base >= 4.2 && < 4.10,
+  build-depends:       base,
                        tasty >= 0.10 && < 0.12,
                        tasty-hunit >= 0.9.2 && < 0.10,
                        tasty-quickcheck >= 0.8 && < 0.9,

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -100,7 +100,7 @@ Library
                        Diagrams.TwoD.Types,
                        Diagrams.TwoD.Vector,
                        Diagrams.Util
-  Build-depends:       base >= 4.6 && < 4.10,
+  Build-depends:       base >= 4.6 && < 4.11,
                        containers >= 0.3 && < 0.6,
                        array >= 0.3 && < 0.6,
                        semigroups >= 0.3.4 && < 0.19,
@@ -124,7 +124,7 @@ Library
                        distributive >=0.2.2 && < 1.0,
                        process >= 1.1 && < 1.5,
                        fsnotify >= 0.2.1 && < 0.3,
-                       directory >= 1.2 && < 1.3,
+                       directory >= 1.2 && < 1.4,
                        unordered-containers >= 0.2 && < 0.3,
                        text >= 0.7.1 && < 1.3,
                        mtl >= 2.0 && < 2.3,


### PR DESCRIPTION
GHC HEAD bumps the version of these libraries. Compilation succeeds with these changes.