### PR TITLE
Fix the GHC 8.2 build

### DIFF
--- a/src/Diagrams/Parametric.hs
+++ b/src/Diagrams/Parametric.hs
@@ -55,7 +55,7 @@ class DomainBounds p where
   --   with numeric scalars).
   domainUpper :: p -> N p
 
-  default domainUpper :: Num n => p -> n
+  default domainUpper :: Num (N p) => p -> N p
   domainUpper = const 1
 
 -- | Type class for querying the values of a parametric object at the


### PR DESCRIPTION
I discovered this when smoke-testing GHC 8.2 on various libraries.

`diagrams-lib` currently fails to build with GHC 8.2. This is because the validity checking for default type signatures tightened up in GHC 8.2 (see also [GHC Trac #12918](https://ghc.haskell.org/trac/ghc/ticket/12918)). In particular, GHC requires that the default type signature of a method must be the same as the non-default type signature, modulo constraints.

This PR fixes a default type signature in `Diagrams.Parametric` to meet this criterion.