### PR TITLE
new boxGrid function

### DIFF
--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -321,7 +321,7 @@ union = mappend
 --   might actually be @11^3@ instead of @10^3@) spaced @0.2@ units
 --   apart.
 boxGrid
-  :: (Traversable v, Applicative v, Num n, Enum n)
+  :: (Traversable v, Additive v, Num n, Enum n)
   => n -> BoundingBox v n -> [Point v n]
 boxGrid f = maybe [] (sequenceA . uncurry (liftI2 mkRange)) . getCorners
   where

--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -323,7 +323,7 @@ union = mappend
 boxGrid
   :: (Traversable v, Applicative v, Num n, Enum n)
   => n -> BoundingBox v n -> [Point v n]
-boxGrid f = maybe [] (sequenceA . uncurry (liftA2 mkRange)) . getCorners
+boxGrid f = maybe [] (sequenceA . uncurry (liftI2 mkRange)) . getCorners
   where
     mkRange lo hi = [lo, (1-f)*lo + f*hi .. hi]
 

--- a/src/Diagrams/BoundingBox.hs
+++ b/src/Diagrams/BoundingBox.hs
@@ -321,9 +321,9 @@ union = mappend
 --   might actually be @11^3@ instead of @10^3@) spaced @0.2@ units
 --   apart.
 boxGrid
-  :: (Traversable v, Applicative v, RealFloat n, Enum n)
-  => n -> BoundingBox v n -> Maybe [Point v n]
-boxGrid f b = (\(c1,c2) -> sequenceA (liftA2 mkRange c1 c2)) <$> getCorners b
+  :: (Traversable v, Applicative v, Num n, Enum n)
+  => n -> BoundingBox v n -> [Point v n]
+boxGrid f = maybe [] (sequenceA . uncurry (liftA2 mkRange)) . getCorners
   where
     mkRange lo hi = [lo, (1-f)*lo + f*hi .. hi]
 


### PR DESCRIPTION
Function for creating a grid of points inside an arbitrary-dimensional box.  I wanted this for sampling a path on its bounding box in order to approximate the centroid of its mass as opposed to the centroid of its vertices.