### PR TITLE
include generic Mainable instance for [(String, d)]

### DIFF
--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -478,22 +478,6 @@ instance Mainable d => Mainable (IO d) where
 
   mainRender opts dio = dio >>= mainRender opts
 
--- | @defaultMultiMainRender@ is an implementation of 'mainRender' where
---   instead of a single diagram it takes a list of diagrams paired with names
---   as input.  The generated executable then takes a @--selection@ option
---   specifying the name of the diagram that should be rendered.  The list of
---   available diagrams may also be printed by passing the option @--list@.
---
---   Typically a backend can write its @[(String,QDiagram b v n Any)]@ instance as
---
---   @
---   instance Mainable [(String,QDiagram b v n Any)] where
---       type MainOpts [(String,QDiagram b v n Any)] = (DiagramOpts, DiagramMultiOpts)
---       mainRender = defaultMultiMainRender
---   @
---
---   We do not provide this instance in general so that backends can choose to
---   opt-in to this form or provide a different instance that makes more sense.
 defaultMultiMainRender :: Mainable d => (MainOpts d, DiagramMultiOpts) -> [(String, d)] -> IO ()
 defaultMultiMainRender (opts,multi) ds =
   if multi^.list
@@ -503,6 +487,15 @@ defaultMultiMainRender (opts,multi) ds =
            Just sel -> case lookup sel ds of
                          Nothing -> putStrLn $ "Unknown diagram: " ++ sel
                          Just d  -> mainRender opts d
+
+-- | This instance allows pairing 'Mainable' things with 'String's;
+--   the generated executable takes a @--selection@ option specifying
+--   the name of the thing that should be rendered.  The list of
+--   available things may also be printed by passing the option
+--   @--list@.
+instance Mainable d => Mainable [(String, d)] where
+  type MainOpts [(String, d)] = (MainOpts d, DiagramMultiOpts)
+  mainRender = defaultMultiMainRender
 
 -- | Display the list of diagrams available for rendering.
 showDiaList :: [String] -> IO ()


### PR DESCRIPTION
Closes #293.

I left in the export of `defaultMultiMainRender` even though backends should have no need for it now, just to avoid a potential source of breakage.