### PR TITLE
Relax process in preparation for GHC 8.2

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -122,7 +122,7 @@ Library
                        linear >= 1.20.1 && < 1.21,
                        adjunctions >= 4.0 && < 5.0,
                        distributive >=0.2.2 && < 1.0,
-                       process >= 1.1 && < 1.5,
+                       process >= 1.1 && < 1.7,
                        fsnotify >= 0.2.1 && < 0.3,
                        directory >= 1.2 && < 1.4,
                        unordered-containers >= 0.2 && < 0.3,


### PR DESCRIPTION
GHC 8.2 is very likely to ship with process-1.6.0.0.

See also:
https://ghc.haskell.org/trac/ghc/wiki/Commentary/Libraries/VersionHistory

FWIW I've checked that the tests still pass.