### PR TITLE
fix capArc for changed dirBetween

### DIFF
--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -470,8 +470,8 @@ capSquare _r c a b = unLoc $ fromVertices [ a, a .+^ v, b .+^ v, b ]
 capArc :: RealFloat n => n -> Point V2 n -> Point V2 n -> Point V2 n -> Trail V2 n
 capArc r c a b = trailLike . moveTo c $ fs
   where
-    fs | r < 0     = scale (-r) $ arcCW  (dirBetween a c) (dirBetween b c)
-       | otherwise = scale r    $ arcCCW (dirBetween a c) (dirBetween b c)
+    fs | r < 0     = scale (-r) $ arcCW  (dirBetween c a) (dirBetween c b)
+       | otherwise = scale r    $ arcCCW (dirBetween c a) (dirBetween c b)
 
 -- | Join together a list of located trails with the given join style.  The
 --   style is given as a function to compute the join given the local information


### PR DESCRIPTION
expandTrail with LineCapRound seems to have been broken in https://github.com/diagrams/diagrams-lib/commit/67901ac38f79d7b469b4bbd33b42248297862c5a. This updates dirBetween use to the new argument order.

(The graphics in the `expandTrail'` haddocks look fine, but maybe they weren't updated for the release?)

diagrams-lib-1.4.1.2:
![wordsearch-example](https://user-images.githubusercontent.com/132113/37106053-0f6e7f5c-2231-11e8-8e61-80dc6a6b7eff.png)

diagrams-lib-1.4.2:
![wordsearch-example](https://user-images.githubusercontent.com/132113/37106070-1bf24f60-2231-11e8-9179-87f2924f59cf.png)

