### PR TITLE
D.Align.combineBoundaries: Compare points by dot product with v

### DIFF
--- a/src/Diagrams/Align.hs
+++ b/src/Diagrams/Align.hs
@@ -94,7 +94,7 @@ combineBoundaries
   :: (InSpace v n a, Metric v, Ord n, F.Foldable f)
   => (v n -> a -> Point v n) -> v n -> f a -> Point v n
 combineBoundaries b v fa
-    = b v $ F.maximumBy (comparing (quadrance . (.-. origin) . b v)) fa
+  = b v $ F.maximumBy (comparing (dot v . (.-.origin) . b v)) fa
 
 instance (Metric v, OrderedField n) => Alignable (Envelope v n) where
   defaultBoundary = envelopeBoundary


### PR DESCRIPTION
Fixes #313 .

When we combine several boundary functions, given a direction v we
want to find the boundary point out of all the constituent boundaries
which is furthest (i.e. most positive) in the direction of v.  This
can be accomplished by taking the dot product with v, which yields a
scalar indicating the signed magnitude of the projection onto
v.  (Presumably the points returned by the boundary function already
lie along v anyway, but this works even if they don't.) Previously we
were comparing points by the squared magnitude of their distance from
the origin, which is wrong because it didn't take positive
vs. negative into account.  e.g. it would prioritize a point which is
far away in the direction of *negative* v.