### PR TITLE
fix for: section producing incorrect results #322

### DIFF
--- a/src/Diagrams/Located.hs
+++ b/src/Diagrams/Located.hs
@@ -175,6 +175,8 @@ instance (InSpace v n a, Fractional n, Parametric a, Sectionable a, Codomain a ~
   splitAtParam (Loc x a) p = (Loc x a1, Loc (x .+^ (a `atParam` p)) a2)
     where (a1,a2) = splitAtParam a p
 
+  section (Loc x a) p1 p2 = Loc (x .+^ (a `atParam` p1)) (section a p1 p2)
+
   reverseDomain (Loc x a) = Loc (x .+^ y) (reverseDomain a)
     where y = a `atParam` domainUpper a
 

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -520,6 +520,8 @@ instance (Metric v, OrderedField n, Real n)
     where
       (t1, t2) = splitAtParam t p
 
+  section (Line t) p1 p2 = Line (section t p1 p2)
+
   reverseDomain = reverseLine
 
 instance (Metric v, OrderedField n, Real n)
@@ -767,6 +769,8 @@ instance (Metric v, OrderedField n, Real n) => EndValues (Trail v n)
 --   'cutLoop' yourself.)
 instance (Metric v, OrderedField n, Real n) => Sectionable (Trail v n) where
   splitAtParam t p = withLine ((wrapLine *** wrapLine) . (`splitAtParam` p)) t
+
+  section t p1 p2 = withLine (wrapLine . (\l -> section l p1 p2)) t
 
   reverseDomain = reverseTrail
 


### PR DESCRIPTION
The section instance of SegTree seems to be correct, but the
instances for Located, Trail, and Trail' Line all used the
default definition which uses splitAtParam instead of SegTree's
implementation of section. The default definition of splitAtParam
is only correct for types which consist of a single segment or are
parametrized by arclength (rather than with each segment having
equal weight).