### PR TITLE
add derived Eq and Ord instances for FixedSegment

### DIFF
--- a/src/Diagrams/Segment.hs
+++ b/src/Diagrams/Segment.hs
@@ -371,7 +371,7 @@ instance (Metric v, OrderedField n)
 --   the absolute locations of the vertices and control points.
 data FixedSegment v n = FLinear (Point v n) (Point v n)
                       | FCubic (Point v n) (Point v n) (Point v n) (Point v n)
-  deriving Show
+  deriving (Eq, Ord, Show)
 
 type instance V (FixedSegment v n) = v
 type instance N (FixedSegment v n) = n


### PR DESCRIPTION
These already exist for Located (Segment Closed v n), which
FixedSegment v n is isomorphic to, but adding the instances avoids
having to do the conversion. The Eq instance is useful to prevent
trivial cases of running segmentSegment on overlaping segments.