### PR TITLE
Relax bounds, add conditional dependency on fail

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -100,7 +100,7 @@ Library
                        Diagrams.TwoD.Types,
                        Diagrams.TwoD.Vector,
                        Diagrams.Util
-  Build-depends:       base >= 4.6 && < 4.14,
+  Build-depends:       base >= 4.8 && < 4.14,
                        containers >= 0.3 && < 0.7,
                        array >= 0.3 && < 0.6,
                        semigroups >= 0.3.4 && < 0.20,
@@ -112,12 +112,12 @@ Library
                        colour >= 2.3.2 && < 2.4,
                        data-default-class < 0.2,
                        fingertree >= 0.1 && < 0.2,
-                       intervals >= 0.7 && < 0.9,
+                       intervals >= 0.7 && < 0.10,
                        lens >= 4.6 && < 4.19,
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.16,
                        filepath,
-                       JuicyPixels >= 3.1.5 && < 3.4,
+                       JuicyPixels >= 3.3.4 && < 3.4,
                        hashable >= 1.1 && < 1.4,
                        linear >= 1.20.1 && < 1.21,
                        adjunctions >= 4.0 && < 5.0,
@@ -135,6 +135,8 @@ Library
                        bytestring >=0.9 && <0.11
   if impl(ghc < 7.6)
     Build-depends: ghc-prim
+  if !impl(ghc >= 8.0)
+    build-depends: fail >= 4.9.0.0 && <4.10
   Hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010


### PR DESCRIPTION
- `fail` backports `MonadFail` class
- Lowerbound on JuicyPixels is so `dynamicMap` is exported from
  `Codec.Picture`
- base >=4.8 to correspond to GHC-7.10 as oldest supported compiler