### PR TITLE
Adding compatability with version 0.16.* of 'optparse-applicative'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## *(Unreleased)*
+
+- Bumps to upper bounds, to allow building with:
+    - `optparse-applicative` (tested with GHC 8.8.4 & 8.10.2)
+
+v1.4.3 (2019-11-06)
+
 ## [v1.4.3](https://github.com/diagrams/diagrams-lib/tree/v1.4.3) (2019-11-06)
 
 - Bumps to upper bounds, to allow building with:

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -115,7 +115,7 @@ Library
                        intervals >= 0.7 && < 0.10,
                        lens >= 4.6 && < 4.20,
                        tagged >= 0.7,
-                       optparse-applicative >= 0.11 && < 0.16,
+                       optparse-applicative >= 0.11 && < 0.17,
                        filepath,
                        JuicyPixels >= 3.3.4 && < 3.4,
                        hashable >= 1.1 && < 1.4,

--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -220,11 +220,17 @@ diagramLoopOpts = DiagramLoopOpts
 --   Taken from Options.Applicative.Extra but without the
 --   short option 'h'.  We want the 'h' for Height.
 helper' :: Parser (a -> a)
-helper' = abortOption ShowHelpText $ mconcat
+helper' = abortOption param $ mconcat
   [ long "help"
   , short '?'
   , help "Show this help text"
   ]
+  where
+#if MIN_VERSION_optparse_applicative(0,16,0)
+    param = ShowHelpText Nothing
+#else
+    param = ShowHelpText 
+#endif
 
 -- | Apply a parser to the command line that includes the standard
 --   program description and help behavior.  Results in parsed commands


### PR DESCRIPTION
Fixes #352 with a tiny bit of CPP in a  module that already was using CPP.