### PR TITLE
Updating use of Kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## *(Unreleased)*
 
 - Bumps to upper bounds, to allow building with:
+    - `base-4.15` (tested with GHC 9.0.1)
     - `optparse-applicative` (tested with GHC 8.8.4 & 8.10.2)
+
+- Updated use of Kinds thoughout the package
+
+- Drop support for GHC-7.10
 
 v1.4.3 (2019-11-06)
 

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -100,7 +100,7 @@ Library
                        Diagrams.TwoD.Types,
                        Diagrams.TwoD.Vector,
                        Diagrams.Util
-  Build-depends:       base >= 4.8 && < 4.14,
+  Build-depends:       base >= 4.9 && < 4.16,
                        containers >= 0.3 && < 0.7,
                        array >= 0.3 && < 0.6,
                        semigroups >= 0.3.4 && < 0.20,

--- a/src/Diagrams/Attributes/Compile.hs
+++ b/src/Diagrams/Attributes/Compile.hs
@@ -25,6 +25,7 @@ import           Data.Typeable
 
 import           Control.Arrow       (second)
 import           Control.Lens        ((%~), (&), _Wrapping')
+import           Data.Kind           (Type)
 import qualified Data.HashMap.Strict as HM
 import           Data.Semigroup
 import           Data.Tree           (Tree (..))
@@ -39,8 +40,8 @@ import           Diagrams.Core.Types (RNode (..), RTree)
 -- splitFills; it's done this way to facilitate testing.
 
 class (AttributeClass (AttrType code), Typeable (PrimType code)) => SplitAttribute code where
-  type AttrType code :: *
-  type PrimType code :: *
+  type AttrType code :: Type
+  type PrimType code :: Type
 
   primOK :: code -> PrimType code -> Bool
 

--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -98,6 +98,7 @@ import           Data.Colour.SRGB
 import           Data.Data
 import           Data.Functor.Identity
 import           Data.IORef
+import           Data.Kind                 (Type)
 import           Data.List                 (delete)
 import           Data.Maybe                (fromMaybe)
 import           Data.Monoid
@@ -361,8 +362,8 @@ instance (Parseable a, Parseable b, Parseable c, Parseable d) => Parseable (a, b
 --   at once, and a type @'ResultOf' d@ that is the type of the final result from
 --   some base case instance.
 class ToResult d where
-  type Args d :: *
-  type ResultOf d :: *
+  type Args d :: Type
+  type ResultOf d :: Type
 
   toResult :: d -> Args d -> ResultOf d
 
@@ -436,7 +437,7 @@ instance ToResult d => ToResult (a -> d) where
 class Mainable d where
   -- | Associated type that describes the options which need to be parsed
   -- from the command-line and passed to @mainRender@.
-  type MainOpts d :: *
+  type MainOpts d :: Type
 
   -- | This method invokes the command-line parser resulting in an options
   -- value or ending the program with an error or help message.

--- a/src/Diagrams/Coordinates.hs
+++ b/src/Diagrams/Coordinates.hs
@@ -19,8 +19,8 @@ module Diagrams.Coordinates
     )
     where
 
+import           Data.Kind       (Type)
 import           Diagrams.Points
-
 import           Linear          (V2 (..), V3 (..), V4 (..))
 
 -- | Types which are instances of the @Coordinates@ class can be
@@ -36,13 +36,13 @@ import           Linear          (V2 (..), V3 (..), V4 (..))
 class Coordinates c where
 
   -- | The type of the final coordinate.
-  type FinalCoord c    :: *
+  type FinalCoord c    :: Type
 
   -- | The type of everything other than the final coordinate.
-  type PrevDim c       :: *
+  type PrevDim c       :: Type
 
   -- | Decomposition of @c@ into applications of ':&'.
-  type Decomposition c :: *
+  type Decomposition c :: Type
     -- Decomposition c = Decomposition (PrevDim c) :& FinalCoord c  (essentially)
 
   -- | Construct a value of type @c@ by providing something of one

--- a/src/Diagrams/Parametric.hs
+++ b/src/Diagrams/Parametric.hs
@@ -22,12 +22,13 @@ module Diagrams.Parametric
 
   ) where
 
+import           Data.Kind (Type)
 import           Diagrams.Core.V
 import qualified Numeric.Interval.Kaucher as I
 
 -- | Codomain of parametric classes.  This is usually either @(V p)@, for relative
 --   vector results, or @(Point (V p))@, for functions with absolute coordinates.
-type family Codomain p :: * -> *
+type family Codomain p :: Type -> Type
 
 -- | Type class for parametric functions.
 class Parametric p where

--- a/src/Diagrams/TwoD/Image.hs
+++ b/src/Diagrams/TwoD/Image.hs
@@ -38,6 +38,7 @@ module Diagrams.TwoD.Image
 import           Codec.Picture
 
 import           Data.Colour          (AlphaColour)
+import           Data.Kind            (Type)
 import           Data.Semigroup
 import           Data.Typeable        (Typeable)
 
@@ -56,12 +57,12 @@ import           Linear.Affine
 
 data Embedded deriving Typeable
 data External deriving Typeable
-data Native (t :: *) deriving Typeable
+data Native (t :: Type) deriving Typeable
 
 -- | 'ImageData' is either a JuicyPixels @DynamicImage@ tagged as 'Embedded' or
 --   a reference tagged as 'External'. Additionally 'Native' is provided for
 --   external libraries to hook into.
-data ImageData :: * -> * where
+data ImageData :: Type -> Type where
   ImageRaster :: DynamicImage -> ImageData Embedded
   ImageRef    :: FilePath -> ImageData External
   ImageNative :: t -> ImageData (Native t)
@@ -71,7 +72,7 @@ data ImageData :: * -> * where
 --   Will typically be created by @loadImageEmb@ or @loadImageExt@ which,
 --   will handle setting the width and height to the actual width and height
 --   of the image.
-data DImage :: * -> * -> * where
+data DImage :: Type -> Type -> Type where
   DImage :: ImageData t -> Int -> Int -> Transformation V2 n -> DImage n t
   deriving Typeable
 


### PR DESCRIPTION
There were many warnings raised during compilation regarding the deprecated use of `*` symbol and `StarIsType` language extension. This pull request fixes these compilation warnings at the expense of dropping GHC-7.10 compilation support.