### PR TITLE
Some eta expansions required to build with GHC-9.0

### DIFF
--- a/src/Diagrams/Transform.hs
+++ b/src/Diagrams/Transform.hs
@@ -125,4 +125,4 @@ movedFrom p = iso (moveOriginTo (negated p)) (moveOriginTo p)
 -- @
 translated :: (InSpace v n a, SameSpace a b, Transformable a, Transformable b)
            => v n -> Iso a b a b
-translated = transformed . translation
+translated v = transformed $ translation v

--- a/src/Diagrams/Transform/Matrix.hs
+++ b/src/Diagrams/Transform/Matrix.hs
@@ -30,7 +30,7 @@ import           Linear.Vector
 
 -- | Build a matrix from a 'Transformation', ignoring the translation.
 mkMat :: (HasBasis v, Num n) => Transformation v n -> v (v n)
-mkMat t = distribute . tabulate $ apply t . unit . el
+mkMat t = distribute . tabulate $ apply t . unit . (\x -> el x)
 
 -- | Build a 3D transformation matrix in homogeneous coordinates from
 --   a 'Transformation V3'.

--- a/src/Diagrams/TwoD/Transform.hs
+++ b/src/Diagrams/TwoD/Transform.hs
@@ -98,7 +98,7 @@ rotateBy = transform . rotation . review turn
 -- @
 rotated :: (InSpace V2 n a, Floating n, SameSpace a b, Transformable a, Transformable b)
         => Angle n -> Iso a b a b
-rotated = transformed . rotation
+rotated a = transformed $ rotation a
 
 -- | @rotationAbout p@ is a rotation about the point @p@ (instead of
 --   around the local origin).


### PR DESCRIPTION
Part of GHC 9.0 is the simplified subsumption in the type system, which effects code which relied on deep skolemization. The `diagrams-lib` package *does* rely on deep skolemization and does not build with GHC 9.0 without some eta expansions to help the type checker. See the [migration guide][0] for more information. 

This pull request applied the eta reductions required to build with GHC 9.0.

[0]: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption