### PR TITLE
Require lens-5.1

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -113,7 +113,7 @@ Library
                        data-default-class < 0.2,
                        fingertree >= 0.1 && < 0.2,
                        intervals >= 0.7 && < 0.10,
-                       lens >= 4.6 && < 5.3,
+                       lens >= 5.1 && < 5.3,
                        tagged >= 0.7,
                        optparse-applicative >= 0.11 && < 0.18,
                        filepath,


### PR DESCRIPTION
Otherwise with `lens < 5.1` you get
```
src/Diagrams/Util.hs:160:34: error:
    Variable not in scope:
      prefixed
        :: [Char]
           -> (FilePath -> Const (First FilePath) FilePath)
           -> p0 String (Const (First FilePath) String)
    |
160 |   hoistMaybe $ config ^? lined . prefixed "package-db: "
    |
```

As a Hackage trustee I revised affected releases:
https://hackage.haskell.org/package/diagrams-lib-1.4.5.2/revisions/
https://hackage.haskell.org/package/diagrams-lib-1.4.5.3/revisions/