### PR TITLE
Remove `defaultLoopRender` and avoid `fsnotify` dependency

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -124,7 +124,6 @@ Library
                        adjunctions >= 4.0 && < 5.0,
                        distributive >=0.2.2 && < 1.0,
                        process >= 1.1 && < 1.7,
-                       fsnotify >= 0.4 && < 0.5,
                        directory >= 1.2 && < 1.4,
                        unordered-containers >= 0.2 && < 0.3,
                        text >= 0.7.1 && < 2.2,


### PR DESCRIPTION
See #370. This branch is to demonstrate how little `fsnotify`-dependent code this library has, and to give me somewhere to point to for projects in which I'm using `diagrams` with the Wasm backend.

Currently, building for Wasm with GHC 9.10 requires a `cabal.project` with:
```
packages: .

if arch(wasm32)
  active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org
```

Then, for example, `nix shell gitlab:haskell-wasm/ghc-wasm-meta?rev=56dfe2478cae35ded335261c854bb8b2a5e7f4d2#all_9_10 -c wasm32-wasi-cabal build all` works.