### PR TITLE
Adapt to NonEmpty API change in diagrams-solve

### DIFF
--- a/src/Diagrams/CubicSpline/Internal.hs
+++ b/src/Diagrams/CubicSpline/Internal.hs
@@ -22,10 +22,13 @@ module Diagrams.CubicSpline.Internal
 import           Diagrams.Solve.Tridiagonal
 
 import           Data.List
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 
 -- | Use the tri-diagonal solver with the appropriate parameters for an open cubic spline.
 solveCubicSplineDerivatives :: Fractional a => [a] -> [a]
-solveCubicSplineDerivatives (x:xs) = solveTriDiagonal as bs as ds
+solveCubicSplineDerivatives [_] = [0]
+solveCubicSplineDerivatives (x:xs) = NE.toList $ solveTriDiagonal (NE.fromList as) (NE.fromList bs) (NE.fromList as) (NE.fromList ds)
   where
     as = replicate (l - 1) 1
     bs = 2 : replicate (l - 2) 4 ++ [2]
@@ -37,7 +40,8 @@ solveCubicSplineDerivatives _ = error "argument to solveCubicSplineDerivatives m
 
 -- | Use the cyclic-tri-diagonal solver with the appropriate parameters for a closed cubic spline.
 solveCubicSplineDerivativesClosed :: Fractional a => [a] -> [a]
-solveCubicSplineDerivativesClosed xs = solveCyclicTriDiagonal as bs as ds 1 1
+solveCubicSplineDerivativesClosed [_] = [0]
+solveCubicSplineDerivativesClosed xs = NE.toList $ solveCyclicTriDiagonal (NE.fromList as) (NE.fromList bs) (NE.fromList as) (NE.fromList ds) 1 1
   where
     as = replicate (l - 1) 1
     bs = replicate l 4


### PR DESCRIPTION
Closes diagrams/diagrams-lib#376

## Summary

`diagrams-solve` commit `55f97904` (post-`v0.2`, 2026-06-04) changed `solveTriDiagonal` and `solveCyclicTriDiagonal` to accept and return `NonEmpty` instead of plain lists. This PR updates the two call sites in `Diagrams.CubicSpline.Internal` to match.

Changes in `src/Diagrams/CubicSpline/Internal.hs`:
- Import `Data.List.NonEmpty`
- Wrap list arguments with `NE.fromList`, unwrap results with `NE.toList`
- Add `[_] = [0]` guards for the single-element case (previously fell through to `error` or relied on solver behavior with degenerate inputs)

## Test plan

- [ ] `stack build` succeeds against HEAD of `diagrams-solve` (commit `55f97904`)
- [ ] `stack test` passes
- [ ] Cubic spline diagrams render correctly (open and closed variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)