### PR TITLE
Fix Haddock escaping of forward slashes in splitTextureFills doc

### DIFF
--- a/src/Diagrams/TwoD/Attributes.hs
+++ b/src/Diagrams/TwoD/Attributes.hs
@@ -414,7 +414,7 @@ instance Typeable n => SplitAttribute (FillTextureLoops n) where
 -- | Push fill attributes down until they are at the root of subtrees
 --   containing only loops. This makes life much easier for backends,
 --   which typically have a semantics where fill attributes are
---   applied to lines/non-closed paths as well as loops/closed paths,
+--   applied to lines\/non-closed paths as well as loops\/closed paths,
 --   whereas in the semantics of diagrams, fill attributes only apply
 --   to loops.
 splitTextureFills


### PR DESCRIPTION
Forward slashes in Haddock comments are parsed as the start of emphasis markup (`/text/`). The existing comment in `splitTextureFills` contained unescaped slashes in `lines/non-closed paths` and `loops/closed paths`, which render incorrectly. Escape them as `\/`.

|Before|After|
|---|---|
|<img width="1201" height="187" alt="Screenshot From 2026-06-07 19-51-34" src="https://github.com/user-attachments/assets/315082fb-2921-4fef-8585-47fd0e444773" />|<img width="1201" height="187" alt="Screenshot From 2026-06-07 19-52-02" src="https://github.com/user-attachments/assets/cdb5994d-abed-4423-80ef-a2ee027b527d" />|