### PR TITLE
Fix -Werror=incomplete-uni-patterns build errors

### DIFF
--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -160,6 +160,7 @@ test-suite tests
                        diagrams-lib,
                        distributive,
                        numeric-extras
+  ghc-options:         -Wno-unused-packages
   default-language:    Haskell2010
 
 benchmark benchmarks

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -157,12 +157,9 @@ test-suite tests
                        tasty-hunit >= 0.9.2 && < 0.11,
                        tasty-quickcheck >= 0.8 && < 0.12,
                        QuickCheck >= 2.7,
-                       deepseq >= 1.3 && < 1.6,
                        diagrams-lib,
-                       lens,
                        distributive,
-                       numeric-extras,
-                       diagrams-solve
+                       numeric-extras
   default-language:    Haskell2010
 
 benchmark benchmarks

--- a/diagrams-lib.cabal
+++ b/diagrams-lib.cabal
@@ -171,5 +171,5 @@ benchmark benchmarks
   build-depends:
     base < 5,
     criterion,
-    diagrams-core,
     diagrams-lib
+  ghc-options:         -Wno-unused-packages

--- a/src/Diagrams/Trail.hs
+++ b/src/Diagrams/Trail.hs
@@ -233,7 +233,10 @@ splitAtParam' (SegTree t) p
                  | otherwise = propFrac $  q           * tSegs
       where propFrac x = let m = mod1 x in (x - m, m)
     (pSegs, pParam) = splitParam p
-    (before, viewl -> seg FT.:< after) = FT.split ((pSegs <) . numSegs) t
+    (before, after_raw) = FT.split ((pSegs <) . numSegs) t
+    (seg, after) = case viewl after_raw of
+      s FT.:< rest -> (s, rest)
+      FT.EmptyL    -> error "splitAtParam': empty trailing tree"
     (segL, segR) = seg `splitAtParam` pParam
     (treeL, treeR) | pParam == 0 = (before        , seg  <| after)
                    | pParam == 1 = (before |> seg ,         after)

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -542,7 +542,8 @@ connect'
 connect' opts n1 n2 =
   withName n1 $ \sub1 ->
   withName n2 $ \sub2 ->
-    let [s,e] = map location [sub1, sub2]
+    let s = location sub1
+        e = location sub2
     in  atop (arrowBetween' opts s e)
 
 -- | Connect two diagrams at point on the perimeter of the diagrams, choosen
@@ -560,7 +561,8 @@ connectPerim'
 connectPerim' opts n1 n2 a1 a2 =
   withName n1 $ \sub1 ->
   withName n2 $ \sub2 ->
-    let [os, oe] = map location [sub1, sub2]
+    let os = location sub1
+        oe = location sub2
         s = fromMaybe os (maxTraceP os (unitX # rotate a1) sub1)
         e = fromMaybe oe (maxTraceP oe (unitX # rotate a2) sub2)
     in  atop (arrowBetween' opts s e)

--- a/src/Diagrams/TwoD/Arrow.hs
+++ b/src/Diagrams/TwoD/Arrow.hs
@@ -105,7 +105,7 @@ module Diagrams.TwoD.Arrow
        , module Diagrams.TwoD.Arrowheads
        ) where
 
-import           Control.Lens              (Lens', Traversal',
+import           Control.Lens              (Lens', Traversal', both,
                                             generateSignatures, lensRules,
                                             makeLensesWith, view, (%~), (&),
                                             (.~), (^.))
@@ -542,8 +542,7 @@ connect'
 connect' opts n1 n2 =
   withName n1 $ \sub1 ->
   withName n2 $ \sub2 ->
-    let s = location sub1
-        e = location sub2
+    let (s, e) = (sub1, sub2) & both %~ location
     in  atop (arrowBetween' opts s e)
 
 -- | Connect two diagrams at point on the perimeter of the diagrams, choosen
@@ -561,8 +560,7 @@ connectPerim'
 connectPerim' opts n1 n2 a1 a2 =
   withName n1 $ \sub1 ->
   withName n2 $ \sub2 ->
-    let os = location sub1
-        oe = location sub2
+    let (os, oe) = (sub1, sub2) & both %~ location
         s = fromMaybe os (maxTraceP os (unitX # rotate a1) sub1)
         e = fromMaybe oe (maxTraceP oe (unitX # rotate a2) sub2)
     in  atop (arrowBetween' opts s e)

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -126,7 +126,8 @@ arrowheadDart theta len shaftWidth = (hd # scale sz, jt)
     j = closeTrail $ fromOffsets [V2 (-jLength) 0, V2 0 (shaftWidth / 2)]
     v = rotate theta unitX
     (t1, t2) = (unit_X ^+^ v, V2 (-0.5) 0 ^-^ v)
-    [b1, b2] = map (reflectY . negated) [t1, t2]
+    b1 = reflectY . negated $ t1
+    b2 = reflectY . negated $ t2
     psi = pi - negated t2 ^. _theta . rad
     jLength = shaftWidth / (2 * tan psi)
 

--- a/src/Diagrams/TwoD/Arrowheads.hs
+++ b/src/Diagrams/TwoD/Arrowheads.hs
@@ -60,7 +60,7 @@ module Diagrams.TwoD.Arrowheads
        , ArrowHT
        ) where
 
-import           Control.Lens            ((&), (.~), (<>~), (^.))
+import           Control.Lens            (both, (&), (.~), (<>~), (%~), (^.))
 import           Data.Default
 import           Data.Monoid             (mempty, (<>))
 
@@ -126,8 +126,7 @@ arrowheadDart theta len shaftWidth = (hd # scale sz, jt)
     j = closeTrail $ fromOffsets [V2 (-jLength) 0, V2 0 (shaftWidth / 2)]
     v = rotate theta unitX
     (t1, t2) = (unit_X ^+^ v, V2 (-0.5) 0 ^-^ v)
-    b1 = reflectY . negated $ t1
-    b2 = reflectY . negated $ t2
+    (b1, b2) = (t1, t2) & both %~ (reflectY . negated)
     psi = pi - negated t2 ^. _theta . rad
     jLength = shaftWidth / (2 * tan psi)
 

--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -82,7 +82,9 @@ perpAtParam :: OrderedField n => Segment Closed V2 n -> n -> V2 n
 perpAtParam (Linear (OffsetClosed a)) _ = negated $ unitPerp a
 perpAtParam cubic t                     = negated $ unitPerp a
   where
-    (Cubic a _ _) = snd $ splitAtParam cubic t
+    a = case snd $ splitAtParam cubic t of
+      Cubic a' _ _ -> a'
+      _            -> error "perpAtParam: impossible"
 
 -- | Compute the offset of a segment.  Given a segment compute the offset
 --   curve that is a fixed distance from the original curve.  For linear
@@ -285,7 +287,7 @@ offsetTrail' opts r t = joinSegments eps j isLoop (opts^.offsetMiterLimit) r end
     where
       eps = opts^.offsetEpsilon
       offset = map (bindLoc (offsetSegment eps r)) . locatedTrailSegments
-      ends | isLoop    = (\(a:as) -> as ++ [a]) . trailPoints $ t
+      ends | isLoop    = case trailPoints t of { (a:as) -> as ++ [a]; [] -> [] }
            | otherwise = tail . trailPoints $ t
       j = fromLineJoin (opts^.offsetJoin)
 
@@ -392,7 +394,7 @@ expandLoop opts r (mapLoc wrapLoop -> t) = trailLike (f r) <> (trailLike . rever
       offset r' = map (bindLoc (offsetSegment eps r')) . locatedTrailSegments
       f r' = joinSegments eps (fromLineJoin (opts^.expandJoin)) True (opts^.expandMiterLimit) r' ends
            . offset r' $ t
-      ends = (\(a:as) -> as ++ [a]) . trailPoints $ t
+      ends = case trailPoints t of { (a:as) -> as ++ [a]; [] -> [] }
 
 -- | Expand a 'Trail' with the given radius and default options.  See 'expandTrail''.
 expandTrail :: RealFloat n => n -> Located (Trail V2 n) -> Path V2 n

--- a/src/Diagrams/TwoD/Offset.hs
+++ b/src/Diagrams/TwoD/Offset.hs
@@ -287,6 +287,7 @@ offsetTrail' opts r t = joinSegments eps j isLoop (opts^.offsetMiterLimit) r end
     where
       eps = opts^.offsetEpsilon
       offset = map (bindLoc (offsetSegment eps r)) . locatedTrailSegments
+      -- FIXME(#381): Use NonEmpty
       ends | isLoop    = case trailPoints t of { (a:as) -> as ++ [a]; [] -> [] }
            | otherwise = tail . trailPoints $ t
       j = fromLineJoin (opts^.offsetJoin)
@@ -394,6 +395,7 @@ expandLoop opts r (mapLoc wrapLoop -> t) = trailLike (f r) <> (trailLike . rever
       offset r' = map (bindLoc (offsetSegment eps r')) . locatedTrailSegments
       f r' = joinSegments eps (fromLineJoin (opts^.expandJoin)) True (opts^.expandMiterLimit) r' ends
            . offset r' $ t
+      -- FIXME(#381): Use NonEmpty
       ends = case trailPoints t of { (a:as) -> as ++ [a]; [] -> [] }
 
 -- | Expand a 'Trail' with the given radius and default options.  See 'expandTrail''.

--- a/src/Diagrams/TwoD/Segment.hs
+++ b/src/Diagrams/TwoD/Segment.hs
@@ -192,8 +192,8 @@ bezierClip eps p_ q_ = filter (allOf both inRange) -- sometimes this returns NaN
     -- iterate with the curves reversed.
     | otherwise = go q p' umin umax tmin' tmax' clip' (not revCurves)
     where
-      chopInterval              = chopCubics p q
-      Just (tminChop, tmaxChop) = chopInterval
+      chopInterval           = chopCubics p q
+      (tminChop, tmaxChop)   = fromJust chopInterval
       p'    = section p tminChop tmaxChop
       clip' = tmaxChop - tminChop
       tmin' = tmax * tminChop + tmin * (1 - tminChop)
@@ -229,8 +229,8 @@ bezierFindRoot eps p tmin tmax
                        go p2 tmid  tmax'
     | otherwise = bezierFindRoot eps newP tmin' tmax'
     where
-      chopInterval              = chopYs (bernsteinCoeffs p)
-      Just (tminChop, tmaxChop) = chopInterval
+      chopInterval           = chopYs (bernsteinCoeffs p)
+      (tminChop, tmaxChop)   = fromJust chopInterval
       newP  = section p tminChop tmaxChop
       clip  = tmaxChop - tminChop
       tmin' = tmax * tminChop + tmin * (1 - tminChop)


### PR DESCRIPTION
I noticed that the merge of https://github.com/diagrams/diagrams-lib/pull/378 was [failing on the master branch](https://github.com/diagrams/diagrams-lib/actions/runs/27114122696).  Would be nice to re-green CI ASAP.

Fixes #382.

## Summary

**`-Werror=incomplete-uni-patterns` fixes** (commit b5ae95d added this flag to CI for GHC >= 9.0):

- Replace two partial `Just (x, y) = expr` pattern bindings in `Diagrams.TwoD.Segment` with `fromJust` (safe: each is inside a `where` clause guarded by `isNothing chopInterval = []`)
- Rewrite the incomplete view-pattern tuple binding in `Diagrams.Trail.splitAtParam'` as a `case viewl` expression
- Fix partial `Cubic` constructor binding in `Diagrams.TwoD.Offset.perpAtParam` with a `case` expression
- Fix partial list-pattern lambdas (`\(a:as) -> ...`) in `Diagrams.TwoD.Offset` with `case` expressions
- Replace `[b1, b2] = map f [t1, t2]` list patterns in `Diagrams.TwoD.Arrowheads` and `Diagrams.TwoD.Arrow` with the `(t1, t2) & both %~ f` tuple idiom

**`-Werror=unused-packages` fixes** (exposed by cabal 3.16 passing transitive deps as `-package-id`):

- Remove stale test-suite dependencies (`deepseq`, `lens`, `diagrams-solve`) that were never directly imported
- Remove explicit `diagrams-core` from benchmark `build-depends` (it is only used transitively via `diagrams-lib`)
- Add `ghc-options: -Wno-unused-packages` to both test-suite and benchmark stanzas to suppress false positives from transitively-exposed packages

## Background

Commit b5ae95d added `-Werror=incomplete-uni-patterns` to the CI for GHC >= 9.0. The faulty patterns predate that change (some by years), so the build has been broken since that CI update.